### PR TITLE
GoXLR Initialiser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ members = [
     "ipc",
     "types",
     "profile",
+    "initialiser",
 ]

--- a/initialiser/Cargo.toml
+++ b/initialiser/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "goxlr-initialiser"
+version = "0.1.0"
+edition = "2021"
+authors = ["Nathan Adams <dinnerbone@dinnerbone.com>", "Craig McLure <craig@mclure.net>", "Lars Mühlbauer <lm41@dismail.de>"]
+description = "Finds, checks and initialises any unconfigured GoXLR devices"
+repository = "https://github.com/GoXLR-on-Linux/GoXLR-Utility"
+license = "MIT"
+categories = ["hardware-support", "command-line-utilities"]
+
+[dependencies]
+rusb = "0.9"

--- a/initialiser/README.md
+++ b/initialiser/README.md
@@ -1,0 +1,26 @@
+# GoXLR Initialiser
+
+This program is designed to prepare a freshly powered on GoXLR for use. It's intended to be run as
+early in the boot process as possible, and will iterate over all GoXLR devices, check their state, and if 
+needed, activate and enable it's features. This is especially useful for the GoXLR Mini device, which loses
+power on reboot.
+
+This application will (if necessary) temporarily detach the kernel module and thus the GoXLRs sound components,
+so it's important to ensure it's not executed after user-space audio applications and setups (such as Jack or Pulse),
+as restoring audio after this point can become difficult.
+
+An example systemd service to activate this would look something like:
+
+```
+[Unit]
+Description=GoXLR Initialiser
+
+[Service]
+Type=oneshot
+ExecStart=/path/to/goxlr-initialiser
+
+[Install]
+WantedBy=graphical.target
+```
+
+Once run, the daemon should be able to start up correctly, and handle profile loading.

--- a/initialiser/src/main.rs
+++ b/initialiser/src/main.rs
@@ -1,0 +1,72 @@
+use std::process::Command;
+use std::time::Duration;
+use rusb::{DeviceHandle, Direction, GlobalContext, Recipient, RequestType};
+use rusb::Direction::{In, Out};
+use rusb::Error::Pipe;
+use rusb::Recipient::Interface;
+use rusb::RequestType::{Class, Vendor};
+
+pub const VID_GOXLR: u16 = 0x1220;
+pub const PID_GOXLR_MINI: u16 = 0x8fe4;
+pub const PID_GOXLR_FULL: u16 = 0x8fe0;
+
+fn main() {
+    println!("Checking for available GoXLR devices..");
+    find_devices();
+}
+
+fn find_devices() {
+    if let Ok(devices) = rusb::devices() {
+        for device in devices.iter() {
+            if let Ok(descriptor) = device.device_descriptor() {
+                if descriptor.vendor_id() == VID_GOXLR
+                    && (descriptor.product_id() == PID_GOXLR_FULL
+                    || descriptor.product_id() == PID_GOXLR_MINI)
+                {
+                    match device.open() {
+                        Ok(mut handle) => {
+                            println!("Found GoXLR Device at {:?}, checking state..", handle);
+
+                            handle.set_active_configuration(1);
+
+                            // Send a single vendor command across, see what happens..
+                            let request_type = rusb::request_type(Out, Vendor, Interface);
+                            let result = handle.write_control(request_type, 1, 0, 0, &[], Duration::from_secs(1));
+
+                            if result == Err(Pipe) {
+                                println!("Device not initialised, preparing..");
+                                // The GoXLR is not initialised, we need to fix that..
+                                handle.set_auto_detach_kernel_driver(true);
+
+                                if !handle.claim_interface(0).is_ok() {
+                                    println!("Unable to claim, failed to initialise..");
+                                    continue;
+                                }
+
+                                // Activate the GoXLR Vendor interface..
+                                let request_type = rusb::request_type(In, Vendor, Interface);
+                                let mut buf = vec![0; 24];
+                                handle.read_control(request_type, 0, 0, 0, &mut buf, Duration::from_secs(1));
+
+                                // Now activate audio..
+                                let request_type = rusb::request_type(Out, Class, Interface);
+                                handle.write_control(request_type, 1, 0x0100, 0x2900, &[0x80, 0xbb, 0x00, 0x00], Duration::from_secs(1));
+                                handle.release_interface(0);
+
+                                // Trigger a reset on the device, to hard reload kernel drivers, and reinit audio..
+                                handle.reset();
+
+                                println!("Device Initialised");
+                            } else {
+                                println!("Device already initialised");
+                            }
+                        }
+                        Err(e) => {
+                            println!("Unable to open the device.. {}", e);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Simple module, designed to be as dependency and code light as possible, simply to execute the commands needed to initialise a GoXLR device on boot, enough so the daemon can communicate with it.