### PR TITLE
docs: mention the compatible streamdeck plugin in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ An unofficial tool to configure and control a TC-Helicon GoXLR or GoXLR Mini on 
 * Exit Actions, including saving profiles and loading other profiles / lighting
 * Multiple Device Support. Run more than one GoXLR on one PC
 * A CLI and API for basic or advanced scripting and automation
+* Streamdeck Integration (through https://github.com/FrostyCoolSlug/goxlr-utility-streamdeck)
 
 ## Downloads
 Downloads are available on the [Releases Page](https://github.com/GoXLR-on-Linux/goxlr-utility/releases) under the


### PR DESCRIPTION
I was looking for info on the Streamdeck support and had to dig my way through the closed issues to finally find #95 with a solution - I think it would make sense to list Streamdeck support and link to the plugin directly in the readme file.