### PR TITLE
Do not try to reload udev when running on an immutable OS

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -145,10 +145,10 @@ assets = [
     { source = "../deployment/deb/_goxlr-daemon", dest = "/usr/share/zsh/vendor-completions/_goxlr-daemon", mode = "0644" },
 ]
 
-# Tiny scriptlet, should reload udev.
+# Tiny scriptlet, should reload udev, unless we are running an immutable OS like Fedora Silverblue.
 post_install_script = """
-udevadm control --reload-rules
-udevadm trigger
+[[ -f /run/ostree-booted ]] || udevadm control --reload-rules
+[[ -f /run/ostree-booted ]] || udevadm trigger
 """
 
 #release = "1"


### PR DESCRIPTION
This is a simple fix for the bug I filed on your Discord server: https://discordapp.com/channels/828348446775574548/1162176770322223104

Reloading udev rules in the post-script raises a `Read-only file system` error on Fedora Silverblue/Kinoite, making it impossible to install goxlr-util.

This fixes that by first checking for a flag file created by `ostree` and only reloading udev if this file does not exist.