### PR TITLE
Added winget publish pipeline

### DIFF
--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,14 @@
+name: Publish to WinGet
+on:
+    release:
+        types: [released]
+jobs:
+    publish:
+        runs-on: windows-latest
+        steps:
+            - uses: vedantmgoyal2009/winget-releaser@v2
+              with:
+                  identifier: GoXLR-on-Linux.GoXLR-Utility
+                  installers-regex: ^goxlr-utility-(\d+(\.\d+)*)\.exe$
+                  token: ${{ secrets.WINGET_TOKEN }}
+                  


### PR DESCRIPTION
This should automate the release/update process for the ``GoXLR-on-Linux.GoXLR-Utility`` winget package.
The pipeline basically consists of only one action that is executed as soon as a new version is released.

There are no manifest files included in this PR as the action will only update the existing one that I have already published in the community repository.

Sadly, you cannot easily merge this PR yet.
Winget works by creating and merging PRs from users on the Github user repository.
So all this pipeline does is automatically creating the PR for you **using your account**.

The pipeline expects an action secret called ``WINGET_TOKEN``, which must be a **classic** personal access token with the scope ``public_repo``.

You will also need a fork of the [winget-pks](https://github.com/microsoft/winget-pkgs) repository on the account that will run the action.
I personally would create a bot account for this action, just to not clutter my github repos. But that's entirely up to you 🙂 

The action has the option to specify the username of the Github account that will be used to create the PR by adding ``fork-user`` to the [winget-releaser](https://github.com/vedantmgoyal2009/winget-releaser) step.