### PR TITLE
Disable submix mitigations on new submix firmware builds

### DIFF
--- a/daemon/src/device.rs
+++ b/daemon/src/device.rs
@@ -2368,7 +2368,7 @@ impl<'a> Device<'a> {
                     self.profile.get_track_by_index(bank, button, index)?,
                     false,
                 )
-                    .await?;
+                .await?;
                 self.update_button_states()?;
             }
             GoXLRCommand::PlayNextSample(bank, button) => {
@@ -3163,8 +3163,8 @@ impl<'a> Device<'a> {
 
         if !map_set
             && (mode == AnimationMode::None
-            || mode == AnimationMode::Ripple
-            || mode == AnimationMode::Simple)
+                || mode == AnimationMode::Ripple
+                || mode == AnimationMode::Simple)
         {
             self.load_colour_map().await?;
         }
@@ -3598,7 +3598,7 @@ impl<'a> Device<'a> {
         match self.hardware.device_type {
             DeviceType::Unknown => false,
             DeviceType::Full => !version_newer_or_equal_to(current, fix_full),
-            DeviceType::Mini => !version_newer_or_equal_to(current, fix_mini)
+            DeviceType::Mini => !version_newer_or_equal_to(current, fix_mini),
         }
     }
 

--- a/daemon/src/device.rs
+++ b/daemon/src/device.rs
@@ -2368,7 +2368,7 @@ impl<'a> Device<'a> {
                     self.profile.get_track_by_index(bank, button, index)?,
                     false,
                 )
-                .await?;
+                    .await?;
                 self.update_button_states()?;
             }
             GoXLRCommand::PlayNextSample(bank, button) => {
@@ -3163,8 +3163,8 @@ impl<'a> Device<'a> {
 
         if !map_set
             && (mode == AnimationMode::None
-                || mode == AnimationMode::Ripple
-                || mode == AnimationMode::Simple)
+            || mode == AnimationMode::Ripple
+            || mode == AnimationMode::Simple)
         {
             self.load_colour_map().await?;
         }
@@ -3583,30 +3583,28 @@ impl<'a> Device<'a> {
     }
 
     fn device_supports_submixes(&self) -> bool {
+        let support_full = VersionNumber(1, 4, Some(2), Some(107));
+        let support_mini = VersionNumber(1, 2, Some(0), Some(46));
+
+        let current = &self.hardware.versions.firmware;
+
         match self.hardware.device_type {
             DeviceType::Unknown => false,
-            DeviceType::Full => version_newer_or_equal_to(
-                &self.hardware.versions.firmware,
-                VersionNumber(1, 4, Some(2), Some(107)),
-            ),
-            DeviceType::Mini => version_newer_or_equal_to(
-                &self.hardware.versions.firmware,
-                VersionNumber(1, 2, Some(0), Some(46)),
-            ),
+            DeviceType::Full => version_newer_or_equal_to(current, support_full),
+            DeviceType::Mini => version_newer_or_equal_to(current, support_mini),
         }
     }
 
     fn device_supports_animations(&self) -> bool {
+        let support_full = VersionNumber(1, 3, Some(40), Some(0));
+        let support_mini = VersionNumber(1, 1, Some(8), Some(0));
+
+        let current = &self.hardware.versions.firmware;
+
         match self.hardware.device_type {
             DeviceType::Unknown => true,
-            DeviceType::Full => version_newer_or_equal_to(
-                &self.hardware.versions.firmware,
-                VersionNumber(1, 3, Some(40), Some(0)),
-            ),
-            DeviceType::Mini => version_newer_or_equal_to(
-                &self.hardware.versions.firmware,
-                VersionNumber(1, 1, Some(8), Some(0)),
-            ),
+            DeviceType::Full => version_newer_or_equal_to(current, support_full),
+            DeviceType::Mini => version_newer_or_equal_to(current, support_mini),
         }
     }
 

--- a/daemon/src/device.rs
+++ b/daemon/src/device.rs
@@ -2995,7 +2995,7 @@ impl<'a> Device<'a> {
             }
 
             // Submix firmware bug mitigation:
-            if new_channel == ChannelName::Headphones || new_channel == ChannelName::LineOut {
+            if self.needs_submix_correction(new_channel) {
                 return Ok(());
             }
 
@@ -3036,7 +3036,7 @@ impl<'a> Device<'a> {
             )?;
 
             // Make sure the new channel comes in with the correct volume..
-            if new_channel == ChannelName::Headphones || new_channel == ChannelName::LineOut {
+            if self.needs_submix_correction(new_channel) {
                 let volume = self.profile.get_channel_volume(new_channel);
                 self.goxlr.set_volume(new_channel, volume)?;
             }
@@ -3069,11 +3069,11 @@ impl<'a> Device<'a> {
         self.goxlr.set_fader(fader_to_switch, existing_channel)?;
 
         // If the channel being moved is either Headphone or Line Out, reset the volume..
-        if new_channel == ChannelName::Headphones || new_channel == ChannelName::LineOut {
+        if self.needs_submix_correction(new_channel) {
             let volume = self.profile.get_channel_volume(new_channel);
             self.goxlr.set_volume(new_channel, volume)?;
         }
-        if existing_channel == ChannelName::Headphones || existing_channel == ChannelName::LineOut {
+        if self.needs_submix_correction(existing_channel) {
             let volume = self.profile.get_channel_volume(existing_channel);
             self.goxlr.set_volume(existing_channel, volume)?;
         }


### PR DESCRIPTION
Since the new TC-Helicon beta firmware releases (1.4.2.110 / 1.2.0.47), Output Channels (Headphones / LineOut) now go to the correct volume when assigned to a fader, removing the need for special mitigations.

This changeset modifies the utility to disable the mitigations when the newer firmware is in use.