### PR TITLE
Repalce BoundedVecDequeue with RB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,12 +767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bounded-vec-deque"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2225b558afc76c596898f5f1b3fc35cfce0eb1b13635cbd7d1b2a7177dc10ccd"
-
-[[package]]
 name = "brotli"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,7 +1885,6 @@ name = "goxlr-audio"
 version = "1.1.1"
 dependencies = [
  "anyhow",
- "bounded-vec-deque",
  "cpal",
  "ebur128",
  "fancy-regex",

--- a/audio/Cargo.toml
+++ b/audio/Cargo.toml
@@ -21,9 +21,6 @@ anyhow = "1.0.75"
 # Logging..
 log = "0.4.20"
 
-# A wrapper around VecDeque to enforce length.
-bounded-vec-deque = "0.1.1"
-
 # Ring Buffer is now needed on all platforms.
 rb = "0.4.1"
 

--- a/audio/src/lib.rs
+++ b/audio/src/lib.rs
@@ -1,16 +1,15 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
+mod audio;
 pub mod player;
 pub mod recorder;
-
-mod audio;
+mod ringbuffer;
 
 #[cfg(target_os = "linux")]
 mod pulse;
 
 #[cfg(not(target_os = "linux"))]
 mod cpal;
-mod ringbuffer;
 
 pub fn get_audio_outputs() -> Vec<String> {
     #[cfg(target_os = "linux")]

--- a/audio/src/lib.rs
+++ b/audio/src/lib.rs
@@ -10,6 +10,7 @@ mod pulse;
 
 #[cfg(not(target_os = "linux"))]
 mod cpal;
+mod ringbuffer;
 
 pub fn get_audio_outputs() -> Vec<String> {
     #[cfg(target_os = "linux")]

--- a/audio/src/recorder.rs
+++ b/audio/src/recorder.rs
@@ -14,10 +14,11 @@ use ebur128::{EbuR128, Mode};
 use fancy_regex::Regex;
 use hound::WavWriter;
 use log::{debug, error, info, trace, warn};
-use rb::{Consumer, Producer, RbConsumer, RbInspector, RbProducer, SpscRb, RB};
+use rb::{Producer, RbConsumer, RbProducer, SpscRb, RB};
 use symphonia::core::audio::{Layout, SignalSpec};
 
 use crate::audio::{get_input, AudioInput, AudioSpecification};
+use crate::ringbuffer::RingBuffer;
 use crate::{get_audio_inputs, AtomicF64};
 
 static NEXT_ID: AtomicU32 = AtomicU32::new(0);
@@ -31,25 +32,6 @@ pub struct BufferedRecorder {
     buffer: RingBuffer<f32>,
     stop: Arc<AtomicBool>,
     is_ready: Arc<AtomicBool>,
-}
-
-pub struct RingBuffer<T> {
-    buffer: SpscRb<T>,
-    consumer: Consumer<T>,
-    producer: Producer<T>,
-}
-
-impl<T: Clone + Copy + Default> RingBuffer<T> {
-    pub fn new(size: usize) -> Self {
-        let buffer = SpscRb::<T>::new(size);
-        let (producer, consumer) = (buffer.producer(), buffer.consumer());
-
-        Self {
-            buffer,
-            consumer,
-            producer,
-        }
-    }
 }
 
 pub struct RingProducer {
@@ -150,51 +132,12 @@ impl BufferedRecorder {
                 sleep(Duration::from_millis(500));
                 continue;
             } else {
-                // Read the latest samples from the input..
+                // Read the latest samples from the input...
                 match input.as_mut().unwrap().read() {
                     Ok(samples) => {
                         if self.buffer_size > 0 {
-                            // Grab some variables for calculating..
-                            let available = self.buffer.buffer.slots_free();
-                            let capacity = self.buffer.buffer.capacity();
-                            let length = samples.len();
-
-                            let consumer = &self.buffer.consumer;
-                            let producer = &self.buffer.producer;
-
-                            // Would we overflow dumping these into the buffer?
-                            if available < length {
-                                // First check, do we have more samples than the buffer size?
-                                if capacity < length {
-                                    // Skip existing samples, and append what we can
-                                    if let Err(e) = consumer.skip_pending() {
-                                        warn!("Unable to Skip Samples: {}", e);
-                                    } else {
-                                        // Calculate the difference, and start point..
-                                        let start = length - (length - capacity);
-                                        if let Err(e) = producer.write(&samples[start..length]) {
-                                            warn!("Error Writing Samples: {}", e);
-                                        }
-                                    }
-                                } else {
-                                    // We need 2 numbers here, the amount of available buffer space
-                                    // and how many samples need to be inserted, then skip the diff
-                                    let skip = length - available;
-
-                                    if let Err(e) = consumer.skip(skip) {
-                                        warn!("Failed to Skip Samples! {}", e);
-                                    } else {
-                                        // Write all available samples to the buffer
-                                        if let Err(e) = producer.write(&samples) {
-                                            warn!("Unable to Write Samples: {}", e);
-                                        }
-                                    }
-                                }
-                            } else if let Err(e) = producer.write(&samples) {
-                                warn!(
-                                    "Unable to Write Samples despite Space: {} - {} - {}",
-                                    available, length, e
-                                );
+                            if let Err(e) = self.buffer.write_into(&samples) {
+                                warn!("Error writing samples to buffer: {}", e);
                             }
                         }
                         for producer in self.producers.lock().unwrap().iter() {
@@ -212,13 +155,8 @@ impl BufferedRecorder {
                         input = None;
                         self.is_ready.store(false, Ordering::Relaxed);
 
-                        // We skip anything pending, to reset our pointer to the 'next' sample
-                        // that's delivered..
-                        if let Err(e) = self.buffer.consumer.skip_pending() {
-                            warn!("Error Skipping samples: {}", e);
-                        }
-
-                        //self.buffer.lock().unwrap().clear();
+                        // Clear the Buffer
+                        self.buffer.clear();
                     }
                 }
             }
@@ -256,9 +194,7 @@ impl BufferedRecorder {
                 input.unwrap().flush();
                 input = None;
                 self.is_ready.store(false, Ordering::Relaxed);
-                if let Err(e) = self.buffer.consumer.skip_pending() {
-                    warn!("Error Skipping samples: {}", e);
-                }
+                self.buffer.clear();
             }
         }
 
@@ -295,7 +231,7 @@ impl BufferedRecorder {
         // So this will likely be spawned in a different thread, to actually handle the record
         // process.. with path being the file path to handle!
 
-        // We create a 4 second buffer for audio input as we need to continue receiving
+        // We create a 4-second buffer for audio input as we need to continue receiving
         // audio while we're creating files, setting up the encoder, and handling the initial buffer.
         let ring_buf = SpscRb::<f32>::new(48000 * 4);
         let (ring_buf_producer, ring_buf_consumer) = (ring_buf.producer(), ring_buf.consumer());
@@ -423,16 +359,10 @@ impl BufferedRecorder {
 
     fn get_samples_from_buffer(&self) -> Vec<f32> {
         if self.buffer_size > 0 {
-            // Create a buffer which can hold all available samples...
-            let mut buffer = vec![0_f32; self.buffer.buffer.count()];
-
-            if let Ok(read) = self.buffer.consumer.get(&mut buffer) {
-                debug!("Read: {} Samples..", read);
-                // We know how many samples were available, return them in their entirety.
-                return Vec::from(&buffer[0..read]);
-            } else {
-                warn!("Error Reading From Buffer..");
-            }
+            return self.buffer.read_buffer().unwrap_or_else(|e| {
+                warn!("Error Reading Samples from Buffer: {}", e);
+                vec![]
+            });
         }
         vec![]
     }

--- a/audio/src/recorder.rs
+++ b/audio/src/recorder.rs
@@ -426,7 +426,7 @@ impl BufferedRecorder {
             // Create a buffer which can hold all available samples...
             let mut buffer = vec![0_f32; self.buffer.buffer.count()];
 
-            if let Ok(read) = self.buffer.consumer.read(&mut buffer) {
+            if let Ok(read) = self.buffer.consumer.get(&mut buffer) {
                 debug!("Read: {} Samples..", read);
                 // We know how many samples were available, return them in their entirety.
                 return Vec::from(&buffer[0..read]);

--- a/audio/src/ringbuffer.rs
+++ b/audio/src/ringbuffer.rs
@@ -1,0 +1,85 @@
+use log::warn;
+use rb::{Consumer, Producer, RbConsumer, RbInspector, RbProducer, SpscRb, RB};
+
+/// This is a simple fixed-sized RingBuffer that permits overflowing
+///
+/// This is designed for situations where you want to continuously write to the buffer, then at
+/// any time retrieve all data currently stored. Useful when handling an audio sample buffer!
+pub struct RingBuffer<T> {
+    buffer: SpscRb<T>,
+    consumer: Consumer<T>,
+    producer: Producer<T>,
+}
+
+impl<T: Clone + Copy + Default> RingBuffer<T> {
+    pub fn new(size: usize) -> Self {
+        let buffer = SpscRb::<T>::new(size);
+        let (producer, consumer) = (buffer.producer(), buffer.consumer());
+
+        Self {
+            buffer,
+            consumer,
+            producer,
+        }
+    }
+
+    pub fn write_into(&self, data: &[T]) -> anyhow::Result<()> {
+        // If we have enough space available in the buffer, we don't need to do anything fancy
+        if self.buffer.slots_free() > data.len() {
+            self.producer.write(data).map_err(anyhow::Error::msg)?;
+            return Ok(());
+        }
+
+        // Is the input data simply too large to fit into the buffer?
+        if self.buffer.capacity() < data.len() {
+            // First thing we need to do is force the consumer pointer to the 'end'
+            self.consumer.skip_pending().map_err(anyhow::Error::msg)?;
+
+            // Calculate where we need to 'start' in the data to be able to fit the tail
+            let start = data.len() - self.buffer.capacity();
+            let data = &data[start..data.len()];
+
+            // Write this into the buffer
+            self.producer.write(data).map_err(anyhow::Error::msg)?;
+
+            return Ok(());
+        }
+
+        // In this final case, we don't have room in the buffer, but the data can fit
+        // we simply need to shift the consumer so there's enough unread, and push in
+        let skip = data.len() - self.buffer.slots_free();
+        self.consumer.skip(skip).map_err(anyhow::Error::msg)?;
+        self.producer.write(data).map_err(anyhow::Error::msg)?;
+
+        Ok(())
+    }
+
+    pub fn read_buffer(&self) -> anyhow::Result<Vec<T>> {
+        let mut buffer = Vec::new();
+        buffer.resize_with(self.buffer.count(), Default::default);
+
+        // Fill the buffer with data...
+        let count = self.consumer.get(&mut buffer).map_err(anyhow::Error::msg)?;
+        Ok(Vec::from(&buffer[0..count]))
+    }
+
+    #[allow(dead_code)]
+    pub fn read_and_clear_buffer(&self) -> anyhow::Result<Vec<T>> {
+        let mut buffer = Vec::new();
+        buffer.resize_with(self.buffer.count(), Default::default);
+
+        // Fill the buffer with data...
+        let count = self
+            .consumer
+            .read(&mut buffer)
+            .map_err(anyhow::Error::msg)?;
+        Ok(Vec::from(&buffer[0..count]))
+    }
+
+    pub fn clear(&self) {
+        // We simply need to skip forward
+        if let Err(e) = self.consumer.skip_pending() {
+            warn!("Error Skipping Buffer: {}", e);
+        }
+    }
+}


### PR DESCRIPTION
BoundedVecDequeue doesn't appear to have a source repository anymore, given that we're using `rb` as a ringbuffer already, create a struct which uses it, but permits overflows to store our cached samples.