### PR TITLE
Support Dynamically Updating recorder

### DIFF
--- a/audio/src/recorder.rs
+++ b/audio/src/recorder.rs
@@ -446,6 +446,8 @@ impl BufferedRecorder {
 
 impl Drop for BufferedRecorder {
     fn drop(&mut self) {
+        debug!("Recorder Dropped, stopping thread..");
+
         // We probably don't need to do this, as drop will only be called after the main
         // thread has terminated, but safety first :)
         self.stop.store(true, Ordering::Relaxed);

--- a/daemon/src/device.rs
+++ b/daemon/src/device.rs
@@ -1651,11 +1651,12 @@ impl<'a> Device<'a> {
                 self.settings.save().await;
 
                 // Reload the Audio Handler...
-                self.stop_all_samples(true, true).await?;
+                self.stop_all_samples(false, true).await?;
 
                 // Drop the Audio Handler..
-                let new_handler = AudioHandler::new(duration)?;
-                self.audio_handler = Some(new_handler);
+                if let Some(handler) = &mut self.audio_handler {
+                    handler.update_record_buffer(duration)?;
+                }
             }
 
             GoXLRCommand::SetFader(fader, channel) => {


### PR DESCRIPTION
This is a relatively small change, rather than destroying and recreating the entire audio context when the pre-buffer is changed, only replace the pre-buffer.