### PR TITLE
Better saving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,7 +1993,6 @@ dependencies = [
  "strum 0.25.0",
  "sys-locale",
  "tasklist",
- "tempfile",
  "tokio",
  "tokio-serde",
  "tts",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -51,7 +51,7 @@ interprocess = { version = "1.2.1", features = ["tokio_support"] }
 notify = "6.1.1"
 json-patch = "1.2.0"
 
-tempfile = "3.8.1"
+#tempfile = "3.8.1"
 
 which = "6.0.0"
 

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -51,8 +51,6 @@ interprocess = { version = "1.2.1", features = ["tokio_support"] }
 notify = "6.1.1"
 json-patch = "1.2.0"
 
-#tempfile = "3.8.1"
-
 which = "6.0.0"
 
 # Language Determination..

--- a/daemon/src/device.rs
+++ b/daemon/src/device.rs
@@ -2476,8 +2476,7 @@ impl<'a> Device<'a> {
                 self.apply_profile(Some(volumes)).await?;
 
                 // Save the profile under a new name (although, don't overwrite if exists!)
-                let file = format!("{}.goxlr", profile_name);
-                let path = self.settings.get_profile_directory().await.join(&file);
+                let path = self.settings.get_profile_directory().await;
                 self.profile.save_as(profile_name.clone(), &path, false)?;
 
                 // Save the profile in the settings

--- a/daemon/src/device.rs
+++ b/daemon/src/device.rs
@@ -147,7 +147,7 @@ impl<'a> Device<'a> {
 
         let mic_profile = match mic_profile {
             Ok(mut profile) => {
-                debug!("Profile Successfully Loaded, Performing Backup..");
+                debug!("Mic Profile Successfully Loaded, Performing Backup..");
                 profile.save(&backup_path, true).unwrap_or_else(|e| {
                     warn!("Unable to Backup Mic Profile: {}", e);
                 });
@@ -2620,7 +2620,7 @@ impl<'a> Device<'a> {
                     Ok(mut profile) => {
                         if persist {
                             // We're persisting this change, so save the backup
-                            debug!("Profile Successfully Loaded, Performing Backup..");
+                            debug!("Mic Profile Successfully Loaded, Performing Backup..");
                             profile.save(&backup, true).unwrap_or_else(|e| {
                                 warn!("Unable to Save Backup: {}", e);
                             });

--- a/daemon/src/device.rs
+++ b/daemon/src/device.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Result};

--- a/daemon/src/device.rs
+++ b/daemon/src/device.rs
@@ -2491,7 +2491,7 @@ impl<'a> Device<'a> {
 
                 // Grab the needed Paths..
                 let profile_path = self.settings.get_profile_directory().await;
-                let backup_path = self.settings.get_profile_directory().await;
+                let backup_path = self.settings.get_backup_directory().await;
 
                 // Attempt to load the profile from the main profile path..
                 let profile = ProfileAdapter::from_named(profile_name.clone(), &profile_path);

--- a/daemon/src/device.rs
+++ b/daemon/src/device.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, bail, Result};
 use chrono::Local;
 use enum_map::EnumMap;
 use enumset::EnumSet;
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use ritelinked::LinkedHashSet;
 use strum::IntoEnumIterator;
 use tokio::sync::mpsc::Sender;
@@ -81,14 +81,9 @@ pub(crate) struct CurrentState {
 }
 
 impl<'a> Device<'a> {
-    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         goxlr: Box<dyn FullGoXLRDevice>,
         hardware: HardwareStatus,
-        profile_name: Option<String>,
-        mic_profile_name: Option<String>,
-        profile_directory: &Path,
-        mic_profile_directory: &Path,
         settings_handle: &'a SettingsHandle,
         global_events: Sender<EventTriggers>,
     ) -> Result<Device<'a>> {
@@ -99,23 +94,58 @@ impl<'a> Device<'a> {
             device_type = " Mini";
         }
 
-        let profile = profile_name.unwrap_or_else(|| DEFAULT_PROFILE_NAME.to_string());
-        let mic_profile = mic_profile_name.unwrap_or_else(|| DEFAULT_MIC_PROFILE_NAME.to_string());
+        let serial = hardware.serial_number.clone();
+        let profile_name = settings_handle.get_device_profile_name(&serial).await;
+        let mic_profile = settings_handle.get_device_mic_profile_name(&serial).await;
+
+        let profile_name = profile_name.unwrap_or_else(|| DEFAULT_PROFILE_NAME.to_string());
+        let mic_profile = mic_profile.unwrap_or_else(|| DEFAULT_MIC_PROFILE_NAME.to_string());
 
         info!(
             "Configuring GoXLR{}, Profile: {}, Mic Profile: {}",
-            device_type, profile, mic_profile
+            device_type, profile_name, mic_profile
         );
 
-        let profile = ProfileAdapter::from_named_or_default(profile, profile_directory);
-        let mic_profile =
-            MicProfileAdapter::from_named_or_default(mic_profile, mic_profile_directory);
+        let profile_path = settings_handle.get_profile_directory().await;
+        let backup_path = settings_handle.get_backup_directory().await;
+        let profile = ProfileAdapter::from_named(profile_name.clone(), &profile_path);
+
+        // Check load situation..
+        let profile = match profile {
+            Ok(mut profile) => {
+                debug!("Profile Successfully Loaded, Performing Backup..");
+                profile.save(&backup_path, true).unwrap_or_else(|e| {
+                    warn!("Unable to Backup Profile: {}", e);
+                });
+                debug!("Backup Complete");
+                profile
+            }
+            Err(e) => {
+                warn!("Failed to Load Profile: {}, checking for backup..", e);
+                match ProfileAdapter::from_named(profile_name, &backup_path) {
+                    Ok(mut profile) => {
+                        info!("Successfully Loaded backup profile");
+
+                        debug!("Overwriting existing corrupt profile..");
+                        profile.save(&profile_path, true)?;
+
+                        // Return the new profile..
+                        profile
+                    }
+                    Err(e) => {
+                        warn!("Unable to Load Backup: {}, loading default", e);
+                        ProfileAdapter::default()
+                    }
+                }
+            }
+        };
+
+        let mic_directory = settings_handle.get_mic_profile_directory().await;
+        let mic_profile = MicProfileAdapter::from_named_or_default(mic_profile, &mic_directory);
 
         let mut audio_handler = None;
         if hardware.device_type == DeviceType::Full {
-            let audio_buffer = settings_handle
-                .get_device_sampler_pre_buffer(&hardware.serial_number)
-                .await;
+            let audio_buffer = settings_handle.get_device_sampler_pre_buffer(&serial).await;
             let audio_loader = AudioHandler::new(audio_buffer);
             debug!("Created Audio Handler..");
             debug!("{:?}", audio_loader);
@@ -132,14 +162,13 @@ impl<'a> Device<'a> {
             debug!("Not Spawning Audio Handler, Device is Mini!");
         }
 
-        let hold_time = settings_handle
-            .get_device_hold_time(&hardware.serial_number)
-            .await;
+        let hold_time = settings_handle.get_device_hold_time(&serial).await;
         let vc_mute_also_mute_cm = settings_handle
-            .get_device_chat_mute_mutes_mic_to_chat(&hardware.serial_number)
+            .get_device_chat_mute_mutes_mic_to_chat(&serial)
             .await;
 
         debug!("--- DEVICE INFO ---");
+        debug!("Serial: {:?}", &serial);
         debug!("Firmware: {:?}", hardware.versions.firmware);
         debug!("DICE: {:?}", hardware.versions.dice);
         debug!("Type: {:?}", hardware.device_type);
@@ -2416,8 +2445,9 @@ impl<'a> Device<'a> {
                 self.apply_profile(Some(volumes)).await?;
 
                 // Save the profile under a new name (although, don't overwrite if exists!)
-                self.profile
-                    .save_as(profile_name.clone(), &profile_directory, false)?;
+                let file = format!("{}.goxlr", profile_name);
+                let path = self.settings.get_profile_directory().await.join(&file);
+                self.profile.save_as(profile_name.clone(), &path, false)?;
 
                 // Save the profile in the settings
                 self.settings
@@ -2429,8 +2459,46 @@ impl<'a> Device<'a> {
                 self.stop_all_samples(true, true).await?;
                 let volumes = self.profile.get_current_state();
 
-                let profile_directory = self.settings.get_profile_directory().await;
-                self.profile = ProfileAdapter::from_named(profile_name, &profile_directory)?;
+                // Grab the needed Paths..
+                let profile_path = self.settings.get_profile_directory().await;
+                let backup_path = self.settings.get_profile_directory().await;
+
+                // Attempt to load the profile from the main profile path..
+                let profile = ProfileAdapter::from_named(profile_name.clone(), &profile_path);
+
+                match profile {
+                    Ok(mut profile) => {
+                        if save_change {
+                            // We're persisting this change, so save the backup
+                            debug!("Profile Successfully Loaded, Performing Backup..");
+                            profile.save(&backup_path, true).unwrap_or_else(|e| {
+                                warn!("Unable to Save Backup: {}", e);
+                            });
+                            debug!("Backup Complete");
+                        }
+                        self.profile = profile;
+                    }
+                    Err(e) => {
+                        if !save_change {
+                            // This isn't a persistent profile change, so we'll avoid checking the
+                            // backups as we're likely shutting down.
+                            return Err(e);
+                        }
+                        warn!("Failed to Load Profile: {}, checking for backup..", e);
+                        match ProfileAdapter::from_named(profile_name, &backup_path) {
+                            Ok(profile) => {
+                                info!("Backup Profile Loaded");
+                                self.profile = profile;
+
+                                debug!("Overwriting existing corrupt profile..");
+                                self.profile.save(&profile_path, true)?;
+                            }
+                            Err(e) => {
+                                bail!("Failed to Load backup profile: {}", e);
+                            }
+                        }
+                    }
+                };
 
                 self.apply_profile(Some(volumes)).await?;
                 if save_change {
@@ -2442,8 +2510,8 @@ impl<'a> Device<'a> {
             }
             GoXLRCommand::LoadProfileColours(profile_name) => {
                 debug!("Loading Colours For Profile: {}", profile_name);
-                let profile_directory = self.settings.get_profile_directory().await;
-                let profile = ProfileAdapter::from_named(profile_name, &profile_directory)?;
+                let profile_path = self.settings.get_profile_directory().await;
+                let profile = ProfileAdapter::from_named(profile_name, &profile_path)?;
                 debug!("Profile Loaded, Applying Colours..");
                 self.profile.load_colour_profile(profile);
 
@@ -2459,13 +2527,11 @@ impl<'a> Device<'a> {
                 self.profile.save(&profile_directory, true)?;
             }
             GoXLRCommand::SaveProfileAs(profile_name) => {
-                let profile_directory = self.settings.get_profile_directory().await;
+                let path = self.settings.get_profile_directory().await;
 
                 // Do a new file verification check..
-                ProfileAdapter::can_create_new_file(profile_name.clone(), &profile_directory)?;
-
-                self.profile
-                    .save_as(profile_name.clone(), &profile_directory, false)?;
+                ProfileAdapter::can_create_new_file(profile_name.clone(), &path)?;
+                self.profile.save_as(profile_name.clone(), &path, false)?;
 
                 // Save the new name in the settings
                 self.settings
@@ -2474,14 +2540,15 @@ impl<'a> Device<'a> {
 
                 self.settings.save().await;
             }
-            GoXLRCommand::DeleteProfile(profile_name) => {
-                if self.profile.name() == profile_name {
+            GoXLRCommand::DeleteProfile(name) => {
+                if self.profile.name() == name {
                     bail!("Unable to Remove Active Profile!");
                 }
 
-                let profile_directory = self.settings.get_profile_directory().await;
-                self.profile
-                    .delete_profile(profile_name.clone(), &profile_directory)?;
+                let profiles = self.settings.get_profile_directory().await;
+                let backups = self.settings.get_backup_directory().await;
+                self.profile.delete_profile(name.clone(), &profiles)?;
+                self.profile.delete_profile(name.clone(), &backups)?;
             }
             GoXLRCommand::ReloadSettings() => {
                 // This is a simple command that will reload the current profile settings

--- a/daemon/src/events.rs
+++ b/daemon/src/events.rs
@@ -108,6 +108,7 @@ pub async fn spawn_event_handler(
                             PathTypes::Samples => state.settings_handle.get_samples_directory().await,
                             PathTypes::Icons => state.settings_handle.get_icons_directory().await,
                             PathTypes::Logs => state.settings_handle.get_log_directory().await,
+                            PathTypes::Backups => state.settings_handle.get_backup_directory().await,
                         }) {
                             warn!("Error Opening Path: {:?}", error);
                         };

--- a/daemon/src/files.rs
+++ b/daemon/src/files.rs
@@ -36,6 +36,7 @@ pub struct FilePaths {
     pub presets: PathBuf,
     pub icons: PathBuf,
     pub samples: PathBuf,
+    pub backups: PathBuf,
 }
 
 #[derive(Debug)]
@@ -58,6 +59,7 @@ impl FileManager {
             presets: settings.get_presets_directory().await,
             icons: settings.get_icons_directory().await,
             samples: settings.get_samples_directory().await,
+            backups: settings.get_backup_directory().await,
         }
     }
 
@@ -102,6 +104,12 @@ impl FileManager {
         if !recorded_path.exists() {
             if let Err(e) = create_path(recorded_path) {
                 warn!("Unable to Create Path: {:?}, {}", recorded_path, e);
+            }
+        }
+
+        if !&paths.backups.exists() {
+            if let Err(e) = create_path(&paths.backups) {
+                warn!("Unable to Create Path: {:?}, {}", &paths.backups, e);
             }
         }
     }

--- a/daemon/src/mic_profile.rs
+++ b/daemon/src/mic_profile.rs
@@ -33,17 +33,6 @@ pub struct MicProfileAdapter {
 }
 
 impl MicProfileAdapter {
-    pub fn from_named_or_default(name: String, directory: &Path) -> Self {
-        match MicProfileAdapter::from_named(name.clone(), directory) {
-            Ok(result) => result,
-            Err(error) => {
-                warn!("Couldn't load mic profile {}: {}", name, error);
-                warn!("Loading Embedded Default Profile");
-                MicProfileAdapter::default()
-            }
-        }
-    }
-
     pub fn from_named(name: String, directory: &Path) -> Result<Self> {
         let path = directory.join(format!("{name}.goxlrMicProfile"));
         if path.is_file() {

--- a/daemon/src/primary_worker.rs
+++ b/daemon/src/primary_worker.rs
@@ -323,7 +323,16 @@ pub async fn spawn_usb_handler(
 
                     DeviceCommand::RunDeviceCommand(serial, command, sender) => {
                         if let Some(device) = devices.get_mut(&serial) {
-                            let _ = sender.send(device.perform_command(command).await);
+                            let result = match device.perform_command(command.clone()).await {
+                                Ok(result) => {
+                                    Ok(result)
+                                }
+                                Err(error) => {
+                                    warn!("Error Executing: {:?}, {}", command, error);
+                                    Err(error)
+                                }
+                            };
+                            let _ = sender.send(result);
                             change_found = true;
                         } else {
                             let _ = sender.send(Err(anyhow!("Device {} is not connected", serial)));

--- a/daemon/src/primary_worker.rs
+++ b/daemon/src/primary_worker.rs
@@ -635,21 +635,7 @@ async fn load_device(
         colour_way,
         usb_device,
     };
-    let profile_directory = settings.get_profile_directory().await;
-    let profile_name = settings.get_device_profile_name(&serial_number).await;
-    let mic_profile_name = settings.get_device_mic_profile_name(&serial_number).await;
-    let mic_profile_directory = settings.get_mic_profile_directory().await;
-    let device = Device::new(
-        handled_device,
-        hardware,
-        profile_name,
-        mic_profile_name,
-        &profile_directory,
-        &mic_profile_directory,
-        settings,
-        global_events,
-    )
-    .await?;
+    let device = Device::new(handled_device, hardware, settings, global_events).await?;
     settings
         .set_device_profile_name(&serial_number, device.profile().name())
         .await;

--- a/daemon/src/profile.rs
+++ b/daemon/src/profile.rs
@@ -62,29 +62,16 @@ pub struct ProfileAdapter {
 }
 
 impl ProfileAdapter {
-    pub fn from_named_or_default(name: String, directory: &Path) -> Self {
-        match ProfileAdapter::from_named(name, directory) {
-            Ok(result) => result,
-            Err(e) => {
-                warn!("Error Loading Profile, falling back to default.. {}", e);
-                ProfileAdapter::default()
-            }
-        }
-    }
-
     pub fn from_named(name: String, directory: &Path) -> Result<Self> {
-        let path = directory.join(format!("{name}.goxlr"));
+        let path = directory.join(format!("{}.goxlr", name));
+
         if path.is_file() {
             debug!("Loading Profile From {}", path.to_string_lossy());
             let file = File::open(path).context("Couldn't open profile for reading")?;
             return ProfileAdapter::from_reader(name, file);
         }
 
-        bail!(
-            "Profile {} does not exist inside {:?}",
-            name,
-            directory.to_string_lossy()
-        );
+        bail!("Profile {} does not exist inside {:?}", name, directory);
     }
 
     pub fn default() -> Self {

--- a/daemon/src/settings.rs
+++ b/daemon/src/settings.rs
@@ -27,6 +27,7 @@ enum Paths {
     Presets,
     Icons,
     Logs,
+    Backups,
 }
 
 impl AsRef<Path> for Paths {
@@ -38,6 +39,7 @@ impl AsRef<Path> for Paths {
             Paths::Presets => Path::new("presets"),
             Paths::Icons => Path::new("icons"),
             Paths::Logs => Path::new("logs"),
+            Paths::Backups => Path::new("backups"),
         }
     }
 }
@@ -60,6 +62,7 @@ impl SettingsHandle {
             presets_directory: None,
             icons_directory: None,
             logs_directory: None,
+            backup_directory: None,
             log_level: Some(LogLevel::Debug),
             open_ui_on_launch: None,
             activate: None,
@@ -259,6 +262,15 @@ impl SettingsHandle {
             directory
         } else {
             self.get_default_path(Paths::Logs)
+        }
+    }
+
+    pub async fn get_backup_directory(&self) -> PathBuf {
+        let settings = self.settings.read().await;
+        if let Some(directory) = settings.backup_directory.clone() {
+            directory
+        } else {
+            self.get_default_path(Paths::Backups)
         }
     }
 
@@ -615,6 +627,7 @@ pub struct Settings {
     presets_directory: Option<PathBuf>,
     icons_directory: Option<PathBuf>,
     logs_directory: Option<PathBuf>,
+    backup_directory: Option<PathBuf>,
     log_level: Option<LogLevel>,
     open_ui_on_launch: Option<bool>,
     activate: Option<String>,

--- a/daemon/src/settings.rs
+++ b/daemon/src/settings.rs
@@ -680,6 +680,11 @@ impl Settings {
 
         let mut tmp_file_name = path.to_path_buf();
         tmp_file_name.set_extension("tmp");
+        if tmp_file_name.exists() {
+            debug!("Temporary file already exists? Removing.");
+            fs::remove_file(&tmp_file_name)?;
+        }
+
         let temp_file = File::create(&tmp_file_name)?;
 
         debug!("Creating Temporary Save File: {:?}", tmp_file_name);

--- a/daemon/src/settings.rs
+++ b/daemon/src/settings.rs
@@ -51,23 +51,27 @@ impl SettingsHandle {
             .context("Couldn't find project directories")?;
         let data_dir = proj_dirs.data_dir();
 
-        let mut settings = Settings::read(&path)?.unwrap_or_else(|| Settings {
-            show_tray_icon: Some(true),
-            selected_locale: None,
-            tts_enabled: Some(false),
-            allow_network_access: Some(false),
-            profile_directory: None,
-            mic_profile_directory: None,
-            samples_directory: None,
-            presets_directory: None,
-            icons_directory: None,
-            logs_directory: None,
-            backup_directory: None,
-            log_level: Some(LogLevel::Debug),
-            open_ui_on_launch: None,
-            activate: None,
-            devices: Some(Default::default()),
-            sample_gain: Some(Default::default()),
+        let mut settings = Settings::read(&path)?.unwrap_or_else(|| {
+            error!("Unable to Load the Settings File, configuring default.");
+
+            Settings {
+                show_tray_icon: Some(true),
+                selected_locale: None,
+                tts_enabled: Some(false),
+                allow_network_access: Some(false),
+                profile_directory: None,
+                mic_profile_directory: None,
+                samples_directory: None,
+                presets_directory: None,
+                icons_directory: None,
+                logs_directory: None,
+                backup_directory: None,
+                log_level: Some(LogLevel::Debug),
+                open_ui_on_launch: None,
+                activate: None,
+                devices: Some(Default::default()),
+                sample_gain: Some(Default::default()),
+            }
         });
 
         // Forward compatibility, if the configured path is the same as the default path

--- a/daemon/src/settings.rs
+++ b/daemon/src/settings.rs
@@ -685,11 +685,11 @@ impl Settings {
             fs::remove_file(&tmp_file_name)?;
         }
 
-        let temp_file = File::create(&tmp_file_name)?;
-
         debug!("Creating Temporary Save File: {:?}", tmp_file_name);
+        let temp_file = File::create(&tmp_file_name)?;
         serde_json::to_writer_pretty(&temp_file, self)?;
         temp_file.sync_all()?;
+        drop(temp_file);
 
         debug!("Save Complete and synced, renaming to {:?}", path);
         if path.exists() {

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -62,6 +62,7 @@ pub enum PathTypes {
     Samples,
     Icons,
     Logs,
+    Backups,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Eq, PartialEq)]

--- a/profile/src/mic_profile.rs
+++ b/profile/src/mic_profile.rs
@@ -142,9 +142,13 @@ impl MicProfileSettings {
     pub fn save(&self, path: impl AsRef<Path>) -> Result<()> {
         let mut tmp_file_name = path.as_ref().to_path_buf();
         tmp_file_name.set_extension("tmp");
-        let temp_file = File::create(&tmp_file_name)?;
+        if tmp_file_name.exists() {
+            debug!("Temporary file already exists? Removing.");
+            fs::remove_file(&tmp_file_name)?;
+        }
 
         debug!("Creating Temporary Save File: {:?}", tmp_file_name);
+        let temp_file = File::create(&tmp_file_name)?;
         self.write_to(&temp_file)?;
 
         // Sync the write to disk..

--- a/profile/src/mic_profile.rs
+++ b/profile/src/mic_profile.rs
@@ -34,7 +34,7 @@ impl MicProfileSettings {
         let buf_reader = BufReader::new(read);
         let mut reader = Reader::from_reader(buf_reader);
 
-        //let parser = EventReader::new(read);
+        let mut valid_profile = false;
 
         let mut equalizer = Equalizer::new();
         let mut equalizer_mini = EqualizerMini::new();
@@ -107,11 +107,21 @@ impl MicProfileSettings {
 
                 // Event::Start/End only occurs for the top level micProfileTree, which has no
                 // attributes, so we don't need to worry about it :)
+                Ok(Event::Start(e)) => {
+                    if String::from_utf8_lossy(e.local_name().as_ref()) == "MicProfileTree" {
+                        valid_profile = true;
+                    }
+                }
+
                 Ok(_) => {}
                 Err(e) => {
                     bail!("Error Parsing Profile: {}", e);
                 }
             }
+        }
+
+        if !valid_profile {
+            bail!("Error: Missing MicProfileTree");
         }
 
         Ok(Self {

--- a/profile/src/mic_profile.rs
+++ b/profile/src/mic_profile.rs
@@ -6,11 +6,12 @@ use crate::microphone::mic_setup::MicSetup;
 use crate::microphone::ui_setup::UiSetup;
 use crate::profile::wrap_start_event;
 use anyhow::{anyhow, bail, Result};
-use log::debug;
+use log::{debug, warn};
 use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, Event};
 use quick_xml::{Reader, Writer};
 use std::collections::HashMap;
 use std::fs;
+use std::fs::File;
 use std::io::{BufReader, Read, Write};
 use std::os::raw::c_float;
 use std::path::Path;
@@ -139,19 +140,27 @@ impl MicProfileSettings {
     }
 
     pub fn save(&self, path: impl AsRef<Path>) -> Result<()> {
-        let temp_file = tempfile::NamedTempFile::new()?;
+        let mut tmp_file_name = path.as_ref().to_path_buf();
+        tmp_file_name.set_extension("tmp");
+        let temp_file = File::create(&tmp_file_name)?;
 
-        debug!("Creating Temporary Save File: {:?}", temp_file.path());
+        debug!("Creating Temporary Save File: {:?}", tmp_file_name);
         self.write_to(&temp_file)?;
 
         // Sync the write to disk..
-        temp_file.as_file().sync_all()?;
+        temp_file.sync_all()?;
 
-        debug!("Save Complete, copying to {:?}", path.as_ref());
-        fs::copy(temp_file.as_ref(), path)?;
+        debug!("Save Complete, renaming to {:?}", path.as_ref());
+        if path.as_ref().exists() {
+            debug!("Target mic profile exists, removing..");
+            fs::remove_file(&path).unwrap_or_else(|e| {
+                warn!("Error Removing File: {}", e);
+            });
+        }
+        debug!("Renaming {:?} to {:?}", tmp_file_name, path.as_ref());
+        fs::rename(tmp_file_name, path)?;
 
-        debug!("Removing Temporary File: {:?}", temp_file);
-        fs::remove_file(temp_file)?;
+        // Ok, we're done.
         Ok(())
     }
 

--- a/profile/src/mic_profile.rs
+++ b/profile/src/mic_profile.rs
@@ -150,7 +150,7 @@ impl MicProfileSettings {
         // Sync the write to disk..
         temp_file.sync_all()?;
 
-        debug!("Save Complete, renaming to {:?}", path.as_ref());
+        debug!("Save Complete and synced, renaming to {:?}", path.as_ref());
         if path.as_ref().exists() {
             debug!("Target mic profile exists, removing..");
             fs::remove_file(&path).unwrap_or_else(|e| {

--- a/profile/src/profile.rs
+++ b/profile/src/profile.rs
@@ -85,9 +85,13 @@ impl Profile {
     pub fn save(&mut self, path: impl AsRef<Path>) -> Result<()> {
         let mut tmp_file_name = path.as_ref().to_path_buf();
         tmp_file_name.set_extension("tmp");
-        let temp_file = File::create(&tmp_file_name)?;
+        if tmp_file_name.exists() {
+            debug!("Temporary file already exists? Removing.");
+            fs::remove_file(&tmp_file_name)?;
+        }
 
         debug!("Creating Temporary Save File: {:?}", &tmp_file_name);
+        let temp_file = File::create(&tmp_file_name)?;
 
         // Create a new ZipFile at the requested location
         let mut archive = zip::ZipWriter::new(&temp_file);

--- a/profile/src/profile.rs
+++ b/profile/src/profile.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::fs::File;
 use std::io::{BufReader, Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::str::FromStr;
 
 use anyhow::{anyhow, bail, Context as ErrorContext, Result};
@@ -11,7 +11,6 @@ use quick_xml::events::{BytesDecl, BytesStart, Event};
 use quick_xml::{Reader, Writer};
 use strum::EnumProperty;
 use strum::IntoEnumIterator;
-use tempfile::NamedTempFile;
 use zip::write::FileOptions;
 
 use crate::components::animation::AnimationTree;

--- a/profile/src/profile.rs
+++ b/profile/src/profile.rs
@@ -113,7 +113,7 @@ impl Profile {
         temp_file.sync_all()?;
 
         // Once complete, we simply move the file over the existing file..
-        debug!("Save Complete, and synced, renaming to {:?}", path.as_ref());
+        debug!("Save Complete and synced, renaming to {:?}", path.as_ref());
         if path.as_ref().exists() {
             debug!("Target profile exists, removing..");
             fs::remove_file(&path).unwrap_or_else(|e| {

--- a/profile/src/profile.rs
+++ b/profile/src/profile.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::fs::File;
 use std::io::{BufReader, Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use anyhow::{anyhow, bail, Context as ErrorContext, Result};
@@ -11,6 +11,7 @@ use quick_xml::events::{BytesDecl, BytesStart, Event};
 use quick_xml::{Reader, Writer};
 use strum::EnumProperty;
 use strum::IntoEnumIterator;
+use tempfile::NamedTempFile;
 use zip::write::FileOptions;
 
 use crate::components::animation::AnimationTree;
@@ -83,12 +84,14 @@ impl Profile {
 
     // Ok, this is better.
     pub fn save(&mut self, path: impl AsRef<Path>) -> Result<()> {
-        let temp_file = tempfile::NamedTempFile::new()?;
+        let mut tmp_file_name = path.as_ref().to_path_buf();
+        tmp_file_name.set_extension("tmp");
+        let temp_file = File::create(&tmp_file_name)?;
 
-        debug!("Creating Temporary Save File: {:?}", temp_file.path());
+        debug!("Creating Temporary Save File: {:?}", &tmp_file_name);
 
         // Create a new ZipFile at the requested location
-        let mut archive = zip::ZipWriter::new(temp_file.as_file());
+        let mut archive = zip::ZipWriter::new(&temp_file);
 
         // Store the profile..
         archive.start_file("profile.xml", FileOptions::default())?;
@@ -108,16 +111,18 @@ impl Profile {
         // The archive has finished writing, we don't need it anymore (keeping it live prevents
         // us from removing the temporary file).
         drop(archive);
-
-        // Syncing Write..
-        temp_file.as_file().sync_all()?;
+        temp_file.sync_all()?;
 
         // Once complete, we simply move the file over the existing file..
-        debug!("Save Complete, copying to {:?}", path.as_ref());
-        fs::copy(temp_file.as_ref(), path)?;
-
-        debug!("Removing Temporary File: {:?}", temp_file);
-        fs::remove_file(temp_file)?;
+        debug!("Save Complete, and synced, renaming to {:?}", path.as_ref());
+        if path.as_ref().exists() {
+            debug!("Target profile exists, removing..");
+            fs::remove_file(&path).unwrap_or_else(|e| {
+                warn!("Error Removing File: {}", e);
+            });
+        }
+        debug!("Renaming {:?} to {:?}", tmp_file_name, path.as_ref());
+        fs::rename(tmp_file_name, &path)?;
         Ok(())
     }
 


### PR DESCRIPTION
This PR does several things to try and guarantee 'safety' when attempting to save and load profiles, including:

* Create backups of last known 'good' configurations so if a profile load fails, there's a fall back profile to use.

This is primarily handled as a 'last effort' attempt to restore a profile. When a profile successfully loads (and only when it successfully loads), a backup of that profile is made as a fail-safe. In the event something happens which results in a profile being corrupt the Utility will instead load that last 'known good' configuration, and replace the broken version. While there is likely to be a small amount of data loss, it should at least guarantee that only recent changes are lost.

* Write the temporary profile alongside the real profile, and use `fs::remove` + `fs::rename` instead of `fs::copy`

During review, I realised that the use of `fs::copy` still requires some level of disk sync as the contents of the profile are copied from the temporary directory into the profile directory (on Linux, this can occur across filesystems). This is bad because an untimely shutdown of the utility could still result in corruption if that copy hasn't synced to disk. This change will ensure that the profile is temporarily written alongside the actual profile, and once complete and synced, will remove the old and rename the new profile. This should result in a simple inode (or equivalent) update, avoiding possible corruption. In the event of a failure / shutdown during the sync process, this should prevent the profile from being overwritten, and under normal operations will guarantee that the new profile is sound.

* Handle Mic Profile Corruption

Prior to this change the Mic profile in the utility would fill with default values then overwrite them as the mic profile is parsed and loaded. This was problematic because if the mic profile had some level of corruption (for example, the file was empty) it would silently load the defaults. This change permits the mic profile loader to emit an error if there is either no content, or the contents of the XML are invalid in the microphone profile. This allows the aforementioned fail safe mechanism to kick in on the Mic Profile if there's a problem.

* Better handle the settings.json file management

`settings.json` now follows the same saving process as the various profiles (although currently doesn't have a 'last good' configuration due to never being written on shutdown), ensuring it should be safely synced to the disk before it's applied. This should guarantee that it's always in a 'good' state, and unexpected shutdowns during writing should no longer cause an issue. As an additional change, the file handle will now be `drop()`ed as soon as the writing is synced and complete to prevent a possible resource hangover / leak lasting until the `save` function completes (I don't know if this is needed, rust docs are kinda vague!). In addition, if for any reason the settings file cannot be loaded, it will now log that error to the log file, rather than silently loading defaults.

* File access is now avoided if the Windows shutdown reason is 'CRITICAL'

The Utility now checks the reason for the `WM_QUERYENDSESSION` call. If the reason for exiting is `ENDSESSION_CRITICAL` it implies that Windows is about to kill our process regardless of our desire to perform shutdown actions. This generally occurs if Windows wants to perform unattended updates while you're away from your computer, or if a `shutdown /f /t now` is called. If the Utility sees this 'CRITICAL' reason for shutting down, if will now longer attempt to execute the 'Shutdown Actions' as it cannot guarantee it can do them safely.

* Minor improvements to FFI

During testing of this patchset, I ran into a problem with what appeared to be a race condition between the initial PnP code, and the PnP thread. This seemingly included an issue with passing pointers between the two separate processes. The FFI changes solve this conflict.




