### PR TITLE
Perform shutdown actions that won't write to the disk in CRITICAL scenarios

### DIFF
--- a/daemon/src/platform/unix.rs
+++ b/daemon/src/platform/unix.rs
@@ -19,7 +19,7 @@ pub async fn spawn_platform_runtime(
         Some(_) = stream.recv() => {
             // Trigger a Shutdown
             debug!("TERM Signal Received, Triggering STOP");
-            let _ = tx.send(EventTriggers::Stop).await;
+            let _ = tx.send(EventTriggers::Stop(false)).await;
         },
         () = shutdown.recv() => {}
     }

--- a/daemon/src/tray/linux.rs
+++ b/daemon/src/tray/linux.rs
@@ -190,7 +190,7 @@ impl Tray for GoXLRTray {
             StandardItem {
                 label: String::from("Quit"),
                 activate: Box::new(|this: &mut GoXLRTray| {
-                    let _ = this.tx.try_send(EventTriggers::Stop);
+                    let _ = this.tx.try_send(EventTriggers::Stop(false));
                 }),
                 ..Default::default()
             }

--- a/daemon/src/tray/macos.rs
+++ b/daemon/src/tray/macos.rs
@@ -80,7 +80,7 @@ async fn run_tray(mut p: RunParams) {
                     OpenPathSamples => tx.try_send(Open(PathTypes::Samples)),
                     OpenPathIcons => tx.try_send(Open(PathTypes::Icons)),
                     OpenPathLogs => tx.try_send(Open(PathTypes::Logs)),
-                    Quit => tx.try_send(EventTriggers::Stop)
+                    Quit => tx.try_send(EventTriggers::Stop(false))
                 };
             },
             () = p.state.shutdown.recv() => {
@@ -392,7 +392,7 @@ impl App {
                 };
 
                 // This is pretty similar to Windows, we loop until we're ready to die..
-                let _ = sender.try_send(EventTriggers::Stop);
+                let _ = sender.try_send(EventTriggers::Stop(false));
 
                 // Now wait for the daemon to actually stop..
                 loop {

--- a/daemon/src/tray/windows.rs
+++ b/daemon/src/tray/windows.rs
@@ -312,7 +312,7 @@ impl WindowProc for GoXLRWindowProc {
                 let _ = match menu_id {
                     // Main Menu
                     0 => self.global_tx.try_send(EventTriggers::Activate),
-                    4 => self.global_tx.try_send(EventTriggers::Stop),
+                    4 => self.global_tx.try_send(EventTriggers::Stop(true)),
 
                     // Open Paths Menu
                     10 => self.global_tx.try_send(Open(PathTypes::Profiles)),
@@ -370,7 +370,7 @@ impl WindowProc for GoXLRWindowProc {
             WM_CLOSE => {
                 // If something tries to close this hidden window, it's a good bet that it wants
                 // us to shutdown, start the shutdown, but don't close the Window.
-                let _ = self.global_tx.try_send(EventTriggers::Stop);
+                let _ = self.global_tx.try_send(EventTriggers::Stop(false));
                 return Some(LRESULT(1));
             }
 
@@ -420,10 +420,12 @@ impl WindowProc for GoXLRWindowProc {
                 if !self.shutdown_triggered {
                     if !critical {
                         debug!("Attempting Shutdown..");
-                        let _ = self.global_tx.try_send(EventTriggers::Stop);
+                        let _ = self.global_tx.try_send(EventTriggers::Stop(false));
                     } else {
-                        debug!("Critical Shutdown Received, skipping to Stage 2..");
-                        let _ = self.global_tx.try_send(EventTriggers::DevicesStopped);
+                        // If we receive an ENDSESSION_CRITICAL we should avoid writing to the
+                        // disk at all cost as we are no longer in control of when we exit.
+                        debug!("Critical Shutdown Received, safely shutting down..");
+                        let _ = self.global_tx.try_send(EventTriggers::Stop(true));
                     }
                     self.shutdown_triggered = true;
                 } else {


### PR DESCRIPTION
This code modifies the 'safe shutdown' behaviours, any shutdown actions which don't require a disk write will be attempted in a 'best effort' case, rather than being completely ignored.