### PR TITLE
Deprecate libUSB and use Win32 calls for PnP

### DIFF
--- a/usb/Cargo.toml
+++ b/usb/Cargo.toml
@@ -34,4 +34,5 @@ windows = { version = "0.52.0", features = [
     "Win32_Security",
     "Win32_System_Threading",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_Devices_DeviceAndDriverInstallation"
 ] }


### PR DESCRIPTION
This code replaces the libUSB PnP behaviour in favour of win32 calls to attempt to better enumerate devices.