### PR TITLE
Vod mode

### DIFF
--- a/daemon/src/device.rs
+++ b/daemon/src/device.rs
@@ -2773,6 +2773,22 @@ impl<'a> Device<'a> {
                     self.load_colour_map().await?;
                 }
             }
+
+            GoXLRCommand::SetVodMode(value) => {
+                let serial = self.serial();
+
+                // Get the current mode..
+                let current = self.settings.get_device_vod_mode(serial).await;
+                if current != value {
+                    self.settings.set_device_vod_mode(serial, value).await;
+
+                    // We need to reapply all routing to reconfigure as needed
+                    for input in BasicInputDevice::iter() {
+                        self.apply_routing(input).await?;
+                    }
+                }
+            }
+
             GoXLRCommand::SetActiveEffectPreset(preset) => {
                 self.load_effect_bank(preset).await?;
                 self.update_button_states()?;

--- a/daemon/src/device.rs
+++ b/daemon/src/device.rs
@@ -277,6 +277,7 @@ impl<'a> Device<'a> {
             .await;
 
         let locked_faders = self.settings.get_device_lock_faders(self.serial()).await;
+        let vod_mode = self.settings.get_device_vod_mode(self.serial()).await;
 
         let submix_supported = self.device_supports_submixes();
 
@@ -346,6 +347,7 @@ impl<'a> Device<'a> {
                 enable_monitor_with_fx: monitor_with_fx,
                 reset_sampler_on_clear: sampler_reset_on_clear,
                 lock_faders: locked_faders,
+                vod_mode,
             },
             button_down: button_states,
             profile_name: self.profile.name().to_owned(),

--- a/daemon/src/settings.rs
+++ b/daemon/src/settings.rs
@@ -1,9 +1,10 @@
 use crate::mic_profile::DEFAULT_MIC_PROFILE_NAME;
 use crate::profile::DEFAULT_PROFILE_NAME;
-use crate::settings::VodMode::Routable;
 use anyhow::{Context, Result};
 use directories::ProjectDirs;
 use goxlr_ipc::{GoXLRCommand, LogLevel};
+use goxlr_types::VodMode;
+use goxlr_types::VodMode::Routable;
 use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -787,11 +788,4 @@ impl Default for DeviceSettings {
             wake_commands: vec![],
         }
     }
-}
-
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, Default)]
-enum VodMode {
-    #[default]
-    Routable,
-    StreamNoMusic,
 }

--- a/ipc/src/device.rs
+++ b/ipc/src/device.rs
@@ -9,7 +9,7 @@ use goxlr_types::{
     MegaphoneStyle, MicrophoneType, MiniEqFrequencies, Mix, MuteFunction, MuteState, OutputDevice,
     PitchStyle, ReverbStyle, RobotStyle, SampleBank, SampleButtons, SamplePlayOrder,
     SamplePlaybackMode, SamplerColourTargets, SimpleColourTargets, SubMixChannelName,
-    VersionNumber, WaterfallDirection,
+    VersionNumber, VodMode, WaterfallDirection,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
@@ -396,6 +396,7 @@ pub struct Settings {
     pub enable_monitor_with_fx: bool,
     pub reset_sampler_on_clear: bool,
     pub lock_faders: bool,
+    pub vod_mode: VodMode,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -14,7 +14,7 @@ use goxlr_types::{
     FaderDisplayStyle, FaderName, GateTimes, GenderStyle, HardTuneSource, HardTuneStyle,
     InputDevice, MegaphoneStyle, MicrophoneType, MiniEqFrequencies, Mix, MuteFunction, MuteState,
     OutputDevice, PitchStyle, ReverbStyle, RobotRange, RobotStyle, SampleBank, SampleButtons,
-    SamplePlayOrder, SamplePlaybackMode, SamplerColourTargets, SimpleColourTargets,
+    SamplePlayOrder, SamplePlaybackMode, SamplerColourTargets, SimpleColourTargets, VodMode,
     WaterfallDirection,
 };
 
@@ -268,6 +268,7 @@ pub enum GoXLRCommand {
     SetMonitorWithFx(bool),
     SetSamplerResetOnClear(bool),
     SetLockFaders(bool),
+    SetVodMode(VodMode),
 
     // These control the current GoXLR 'State'..
     SetActiveEffectPreset(EffectBankPresets),

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -809,6 +809,15 @@ pub enum WaterfallDirection {
     Off,
 }
 
+#[derive(Default, Debug, Copy, Clone, EnumIter, Display, PartialEq, Eq)]
+#[cfg_attr(feature = "clap", derive(ValueEnum))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum VodMode {
+    #[default]
+    Routable,
+    StreamNoMusic,
+}
+
 #[derive(Default, Debug, Clone, Enum, PartialEq, Eq)]
 #[cfg_attr(feature = "clap", derive(ValueEnum))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]


### PR DESCRIPTION
This PR introduces a 'VOD Mode' for the mini.

The Sampler / VOD channel now has a 'Stream Mix (No Audio)' setting, and when enabled the code will keep the Sampler / VOD channel in-sync with the Stream Mix channel, with the Music channel permanently disabled. 

Changes are handled in a 'hard coded' way, so they wont be persisted to the profile, this allows users to easily switch back and forth if needed.