### PR TITLE
Macos aggergate disable

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -63,6 +63,12 @@ rather than through additional parameters. When that comes, this will be removed
 static OVERRIDE_SAMPLER_INPUT: Mutex<Option<String>> = Mutex::new(None);
 static OVERRIDE_SAMPLER_OUTPUT: Mutex<Option<String>> = Mutex::new(None);
 
+/**
+    This is also ugly, but for now it's important to allow users to simply disable aggregate
+    management, and have the utility obey.
+*/
+pub static HANDLE_MACOS_AGGREGATES: Mutex<Option<bool>> = Mutex::new(Some(true));
+
 lazy_static! {
     /**
         This is a fetcher of the system locale, used for language and translations of the UI.
@@ -108,6 +114,10 @@ async fn run_utility() -> Result<()> {
     // they get moved into the settings loader, which just causes headaches :D
     let args: Cli = Cli::parse();
     let settings = SettingsHandle::load(args.config).await?;
+
+    // Set the MacOS Aggregate management..
+    let aggregates = settings.get_macos_handle_aggregates().await;
+    HANDLE_MACOS_AGGREGATES.lock().unwrap().replace(aggregates);
 
     // Configure and / or create the log path, and file name.
     let log_path = settings.get_log_directory().await;

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -197,6 +197,12 @@ async fn run_utility() -> Result<()> {
         warn!("Unable to calculate timezone, using UTC for log timestamps");
     }
 
+    if cfg!(target_os = "macos") {
+        debug!(
+            "Configure MacOS Aggregates: {:?}",
+            HANDLE_MACOS_AGGREGATES.lock().unwrap().unwrap()
+        );
+    }
     if is_root() {
         if args.force_root {
             error!("GoXLR Utility running as root, this is generally considered bad.");

--- a/daemon/src/platform/macos/runtime.rs
+++ b/daemon/src/platform/macos/runtime.rs
@@ -35,7 +35,7 @@ pub async fn run(tx: mpsc::Sender<EventTriggers>, mut stop: Shutdown) -> Result<
         }
     }
 
-    if HANDLE_MACOS_AGGREGATES.lock().unwrao().unwrap() == false {
+    if HANDLE_MACOS_AGGREGATES.lock().unwrap().unwrap() == false {
         return Ok(());
     }
 

--- a/daemon/src/platform/macos/runtime.rs
+++ b/daemon/src/platform/macos/runtime.rs
@@ -35,7 +35,7 @@ pub async fn run(tx: mpsc::Sender<EventTriggers>, mut stop: Shutdown) -> Result<
         }
     }
 
-    if HANDLE_MACOS_AGGREGATES.lock().unwrap().unwrap() == false {
+    if !HANDLE_MACOS_AGGREGATES.lock().unwrap().unwrap() {
         return Ok(());
     }
 

--- a/daemon/src/platform/macos/runtime.rs
+++ b/daemon/src/platform/macos/runtime.rs
@@ -35,7 +35,7 @@ pub async fn run(tx: mpsc::Sender<EventTriggers>, mut stop: Shutdown) -> Result<
         }
     }
 
-    if HANDLE_MACOS_AGGREGATES.unwrap() == false {
+    if HANDLE_MACOS_AGGREGATES.lock().unwrao().unwrap() == false {
         return Ok(());
     }
 

--- a/daemon/src/platform/macos/runtime.rs
+++ b/daemon/src/platform/macos/runtime.rs
@@ -13,6 +13,7 @@ use crate::platform::macos::core_audio::{
 };
 use crate::platform::macos::device::{Inputs, Outputs};
 use crate::shutdown::Shutdown;
+use crate::HANDLE_MACOS_AGGREGATES;
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::mpsc;
 use tokio::time::sleep;
@@ -32,6 +33,10 @@ pub async fn run(tx: mpsc::Sender<EventTriggers>, mut stop: Shutdown) -> Result<
                 warn!("Unable to Destroy Aggregate Device {}", device);
             }
         }
+    }
+
+    if HANDLE_MACOS_AGGREGATES.unwrap() == false {
+        return Ok(());
     }
 
     // Ticker to monitor for device changes..

--- a/daemon/src/primary_worker.rs
+++ b/daemon/src/primary_worker.rs
@@ -449,6 +449,7 @@ async fn get_daemon_status(
                 app_path: app_check.clone(),
             },
             platform: env::consts::OS.to_string(),
+            handle_macos_aggregates: settings.get_macos_handle_aggregates().await,
         },
         paths: Paths {
             profile_directory: settings.get_profile_directory().await,

--- a/daemon/src/primary_worker.rs
+++ b/daemon/src/primary_worker.rs
@@ -17,6 +17,7 @@ use goxlr_usb::{PID_GOXLR_FULL, PID_GOXLR_MINI};
 use json_patch::diff;
 use log::{debug, error, info, warn};
 use std::collections::{BTreeMap, HashMap};
+use std::env;
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast::Sender as BroadcastSender;
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -447,6 +448,7 @@ async fn get_daemon_status(
                 active_path: settings.get_activate().await,
                 app_path: app_check.clone(),
             },
+            platform: env::consts::OS.to_string(),
         },
         paths: Paths {
             profile_directory: settings.get_profile_directory().await,

--- a/daemon/src/primary_worker.rs
+++ b/daemon/src/primary_worker.rs
@@ -347,9 +347,11 @@ pub async fn spawn_usb_handler(
                                 change_found = true;
                                 let _ = sender.send(Ok(()));
                             }
-                            DaemonCommand::DisableMacOSAggregates(value) => {
+                            DaemonCommand::HandleMacOSAggregates(value) => {
                                 settings.set_macos_handle_aggregates(value).await;
                                 settings.save().await;
+
+                                change_found = true;
                                 let _ = sender.send(Ok(()));
                             }
                         }

--- a/daemon/src/primary_worker.rs
+++ b/daemon/src/primary_worker.rs
@@ -347,6 +347,11 @@ pub async fn spawn_usb_handler(
                                 change_found = true;
                                 let _ = sender.send(Ok(()));
                             }
+                            DaemonCommand::DisableMacOSAggregates(value) => {
+                                settings.set_macos_handle_aggregates(value).await;
+                                settings.save().await;
+                                let _ = sender.send(Ok(()));
+                            }
                         }
                     },
 

--- a/daemon/src/settings.rs
+++ b/daemon/src/settings.rs
@@ -59,6 +59,7 @@ impl SettingsHandle {
                 selected_locale: None,
                 tts_enabled: Some(false),
                 allow_network_access: Some(false),
+                macos_handle_aggregates: None,
                 profile_directory: None,
                 mic_profile_directory: None,
                 samples_directory: None,
@@ -138,6 +139,10 @@ impl SettingsHandle {
             settings.allow_network_access = Some(false);
         }
 
+        if settings.macos_handle_aggregates.is_none() {
+            settings.macos_handle_aggregates = Some(true);
+        }
+
         if settings.devices.is_none() {
             settings.devices = Some(Default::default());
         }
@@ -213,6 +218,16 @@ impl SettingsHandle {
     pub async fn set_allow_network_access(&self, enabled: bool) {
         let mut settings = self.settings.write().await;
         settings.allow_network_access = Some(enabled);
+    }
+
+    pub async fn set_macos_handle_aggregates(&self, enabled: bool) {
+        let mut settings = self.settings.write().await;
+        settings.macos_handle_aggregates = Some(enabled);
+    }
+
+    pub async fn get_macos_handle_aggregates(&self) -> bool {
+        let settings = self.settings.read().await;
+        settings.macos_handle_aggregates.unwrap()
     }
 
     pub async fn get_profile_directory(&self) -> PathBuf {
@@ -625,6 +640,7 @@ pub struct Settings {
     selected_locale: Option<String>,
     tts_enabled: Option<bool>,
     allow_network_access: Option<bool>,
+    macos_handle_aggregates: Option<bool>,
     profile_directory: Option<PathBuf>,
     mic_profile_directory: Option<PathBuf>,
     samples_directory: Option<PathBuf>,

--- a/ipc/src/device.rs
+++ b/ipc/src/device.rs
@@ -38,6 +38,7 @@ pub struct DaemonConfig {
     pub log_level: LogLevel,
     pub open_ui_on_launch: bool,
     pub platform: String,
+    pub handle_macos_aggregates: bool,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/ipc/src/device.rs
+++ b/ipc/src/device.rs
@@ -37,6 +37,7 @@ pub struct DaemonConfig {
     pub allow_network_access: bool,
     pub log_level: LogLevel,
     pub open_ui_on_launch: bool,
+    pub platform: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -94,6 +94,8 @@ pub enum DaemonCommand {
 
     SetSampleGainPct(String, u8),
     ApplySampleChange,
+
+    DisableMacOSAggregates(bool),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -95,7 +95,7 @@ pub enum DaemonCommand {
     SetSampleGainPct(String, u8),
     ApplySampleChange,
 
-    DisableMacOSAggregates(bool),
+    HandleMacOSAggregates(bool),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Added the ability to disable Utility managed aggregates, this allows users to use tools like loopback to manage GoXLR resources.