### PR TITLE
fix: Fix MacOS implementation and reinstate ci builds

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -138,95 +138,95 @@ jobs:
           name: rpm-artifact
           path: ./target/generate-rpm/*.rpm
 
-#  build_macos:
-#    name: "Create MacOS Builds"
-#    strategy:
-#      matrix:
-#        targets: [ x86_64-apple-darwin, aarch64-apple-darwin ]
-#    runs-on: macos-latest
-#    needs: [ get_version ]
-#    steps:
-#      - name: "Checkout Repository"
-#        uses: actions/checkout@v4
-#        with:
-#          path: goxlr-utility
-#
-#      # Now Checkout the App Wrappers repository..
-#      - name: "Check out GoXLR Utility UI"
-#        uses: actions/checkout@v4
-#        with:
-#          repository: frostycoolslug/goxlr-utility-ui
-#          path: goxlr-utility-ui
-#
-#      - name: "Install Rust"
-#        uses: dtolnay/rust-toolchain@stable
-#
-#      - name: "Loading Cache"
-#        uses: actions/cache@v4
-#        continue-on-error: false
-#        with:
-#          path: |
-#            ~/.cargo/bin/
-#            ~/.cargo/registry/index/
-#            ~/.cargo/registry/cache/
-#            ~/.cargo/git/db/
-#            goxlr-utility/target
-#          key: ${{ runner.os }}-${{ matrix.targets }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
-#          restore-keys: ${{ runner.os }}-${{ matrix.targets }}-cargo-release-
-#
-#      - name: "Add rust target support"
-#        run: rustup target add ${{ matrix.targets }}
-#
-#      - name: "Build Package"
-#        run: ./goxlr-utility/ci/build-macos '${{ matrix.targets }}' '${{ needs.get_version.outputs.version }}'
-#        shell: bash
-#
-#      - name: "Upload MacOS zip Artifact"
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: macos-artifact-${{ matrix.targets }}
-#          path: ./macos_binaries_*.tgz
-#
-#  package_macos:
-#    name: "Package MacOS Binaries"
-#    runs-on: macos-latest
-#    needs: [ get_version, build_macos ]
-#
-#    steps:
-#      - name: "Checkout Repository"
-#        uses: actions/checkout@v4
-#
-#      - name: "Download x86_64 Artifact"
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: "macos-artifact-x86_64-apple-darwin"
-#
-#      - name: "Download aarch64 Artifact"
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: "macos-artifact-aarch64-apple-darwin"
-#
-#      - name: "Install Packages App.."
-#        run: |
-#          wget http://s.sudre.free.fr/Software/files/Packages.dmg
-#          hdiutil attach Packages.dmg
-#          sudo installer -pkg /Volumes/Packages\ 1.2.10/Install\ Packages.pkg -target /
-#      - name: "Build LIPO Binaries"
-#        run: ./ci/build-macos-package '${{ needs.get_version.outputs.version }}'
-#        shell: bash
-#
-#      - name: "Upload MacOS final Artifact"
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: macos-artifact
-#          path: ./goxlr-utility-macos-*.pkg
-#
-#      - name: "Remove x64 artifact"
-#        uses: geekyeggo/delete-artifact@v4
-#        with:
-#          name: macos-artifact-x86_64-apple-darwin
-#
-#      - name: "Remove aarch artifact"
-#        uses: geekyeggo/delete-artifact@v4
-#        with:
-#          name: macos-artifact-aarch64-apple-darwin
+  build_macos:
+    name: "Create MacOS Builds"
+    strategy:
+      matrix:
+        targets: [ x86_64-apple-darwin, aarch64-apple-darwin ]
+    runs-on: macos-latest
+    needs: [ get_version ]
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          path: goxlr-utility
+
+      # Now Checkout the App Wrappers repository..
+      - name: "Check out GoXLR Utility UI"
+        uses: actions/checkout@v4
+        with:
+          repository: frostycoolslug/goxlr-utility-ui
+          path: goxlr-utility-ui
+
+      - name: "Install Rust"
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: "Loading Cache"
+        uses: actions/cache@v4
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            goxlr-utility/target
+          key: ${{ runner.os }}-${{ matrix.targets }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.targets }}-cargo-release-
+
+      - name: "Add rust target support"
+        run: rustup target add ${{ matrix.targets }}
+
+      - name: "Build Package"
+        run: ./goxlr-utility/ci/build-macos '${{ matrix.targets }}' '${{ needs.get_version.outputs.version }}'
+        shell: bash
+
+      - name: "Upload MacOS zip Artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-artifact-${{ matrix.targets }}
+          path: ./macos_binaries_*.tgz
+
+  package_macos:
+    name: "Package MacOS Binaries"
+    runs-on: macos-latest
+    needs: [ get_version, build_macos ]
+
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v4
+
+      - name: "Download x86_64 Artifact"
+        uses: actions/download-artifact@v4
+        with:
+          name: "macos-artifact-x86_64-apple-darwin"
+
+      - name: "Download aarch64 Artifact"
+        uses: actions/download-artifact@v4
+        with:
+          name: "macos-artifact-aarch64-apple-darwin"
+
+      - name: "Install Packages App.."
+        run: |
+          wget http://s.sudre.free.fr/Software/files/Packages.dmg
+          hdiutil attach Packages.dmg
+          sudo installer -pkg /Volumes/Packages\ 1.2.10/Install\ Packages.pkg -target /
+      - name: "Build LIPO Binaries"
+        run: ./ci/build-macos-package '${{ needs.get_version.outputs.version }}'
+        shell: bash
+
+      - name: "Upload MacOS final Artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-artifact
+          path: ./goxlr-utility-macos-*.pkg
+
+      - name: "Remove x64 artifact"
+        uses: geekyeggo/delete-artifact@v4
+        with:
+          name: macos-artifact-x86_64-apple-darwin
+
+      - name: "Remove aarch artifact"
+        uses: geekyeggo/delete-artifact@v4
+        with:
+          name: macos-artifact-aarch64-apple-darwin

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -222,11 +222,11 @@ jobs:
           path: ./goxlr-utility-macos-*.pkg
 
       - name: "Remove x64 artifact"
-        uses: geekyeggo/delete-artifact@v4
+        uses: geekyeggo/delete-artifact@v5.1.0
         with:
           name: macos-artifact-x86_64-apple-darwin
 
       - name: "Remove aarch artifact"
-        uses: geekyeggo/delete-artifact@v4
+        uses: geekyeggo/delete-artifact@v5.1.0
         with:
           name: macos-artifact-aarch64-apple-darwin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,36 +38,36 @@ jobs:
       - name: Performing Clippy Test
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-  #  check_macos:
-  #    name: Checking for MacOS
-  #    runs-on: macos-latest
-  #    steps:
-  #      - uses: actions/checkout@v4
-  #      - uses: dtolnay/rust-toolchain@stable
-  #        with:
-  #          components: clippy
-  #
-  #      - name: Preparing Cache..
-  #        uses: actions/cache@v4
-  #        continue-on-error: false
-  #        with:
-  #          path: |
-  #            ~/.cargo/bin/
-  #            ~/.cargo/registry/index/
-  #            ~/.cargo/registry/cache/
-  #            ~/.cargo/git/db/
-  #            target/
-  #          key: ${{ runner.os }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
-  #          restore-keys: ${{ runner.os }}-cargo-debug-
-  #
-  #      - name: Running Tests
-  #        run: cargo check --all-features
-  #
-  #      - name: Checking Formatting
-  #        run: cargo fmt --all -- --check
-  #
-  #      - name: Performing Clippy Test
-  #        run: cargo clippy --all-targets --all-features -- -D warnings
+  check_macos:
+    name: Checking for MacOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Preparing Cache..
+        uses: actions/cache@v4
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-debug-
+
+      - name: Running Tests
+        run: cargo check --all-features
+
+      - name: Checking Formatting
+        run: cargo fmt --all -- --check
+
+      - name: Performing Clippy Test
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
   check_windows:
     name: Checking for Windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,5 +41,5 @@ jobs:
             ./rpm-artifact/goxlr-utility-${{ needs.get_version.outputs.version }}-1.x86_64.rpm
             ./rpm-artifact/goxlr-utility-${{ needs.get_version.outputs.version }}-suse.x86_64.rpm
             ./windows-artifact/goxlr-utility-${{ needs.get_version.outputs.version }}.exe
-#            ./macos-artifact/goxlr-utility-macos-${{ needs.get_version.outputs.version }}-intel.pkg
-#            ./macos-artifact/goxlr-utility-macos-${{ needs.get_version.outputs.version }}-m1.pkg
+            ./macos-artifact/goxlr-utility-macos-${{ needs.get_version.outputs.version }}-intel.pkg
+            ./macos-artifact/goxlr-utility-macos-${{ needs.get_version.outputs.version }}-m1.pkg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,6 +883,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d59b4c170e16f0405a2e95aff44432a0d41aa97675f3d52623effe95792a037"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,22 +1125,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
-name = "cocoa"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79398230a6e2c08f5c9760610eb6924b52aa9e7950a619602baba59dcbbdbb2"
-dependencies = [
- "bitflags 2.6.0",
- "block",
- "cocoa-foundation 0.2.0",
- "core-foundation 0.10.0",
- "core-graphics",
- "foreign-types 0.5.0",
- "libc",
- "objc",
-]
-
-[[package]]
 name = "cocoa-foundation"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,21 +1133,7 @@ dependencies = [
  "bitflags 1.3.2",
  "block",
  "core-foundation 0.9.4",
- "core-graphics-types 0.1.3",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa-foundation"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14045fb83be07b5acf1c0884b2180461635b433455fa35d1cd6f17f1450679d"
-dependencies = [
- "bitflags 2.6.0",
- "block",
- "core-foundation 0.10.0",
- "core-graphics-types 0.2.0",
+ "core-graphics-types",
  "libc",
  "objc",
 ]
@@ -1249,19 +1228,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core-graphics"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
-dependencies = [
- "bitflags 2.6.0",
- "core-foundation 0.10.0",
- "core-graphics-types 0.2.0",
- "foreign-types 0.5.0",
- "libc",
-]
-
-[[package]]
 name = "core-graphics-types"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,17 +1235,6 @@ checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
-dependencies = [
- "bitflags 2.6.0",
- "core-foundation 0.10.0",
  "libc",
 ]
 
@@ -1528,6 +1483,18 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a0d569e003ff27784e0e14e4a594048698e0c0f0b66cabcb51511be55a7caa0"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -1915,28 +1882,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared 0.3.1",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.72",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1944,12 +1890,6 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2180,11 +2120,10 @@ dependencies = [
  "chrono",
  "clap 4.5.11",
  "clap_complete",
- "cocoa",
- "cocoa-foundation 0.2.0",
  "core-foundation 0.10.0",
  "coreaudio-sys",
  "directories",
+ "dispatch2",
  "dunce",
  "enum-map",
  "enumset",
@@ -2213,8 +2152,9 @@ dependencies = [
  "mslnk",
  "nix 0.29.0",
  "notify",
- "objc-foundation",
- "objc-rs",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "opener",
  "reqwest",
  "ritelinked",
@@ -3582,23 +3522,126 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc-foundation"
-version = "0.1.1"
+name = "objc2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+checksum = "3531f65190d9cff863b77a99857e74c314dd16bf56c538c4b57c7cbc3f3a6e59"
 dependencies = [
- "block",
- "objc",
- "objc_id",
+ "objc2-encode",
 ]
 
 [[package]]
-name = "objc-rs"
-version = "0.2.8"
+name = "objc2-app-kit"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a1e7069a2525126bf12a9f1f7916835fafade384fb27cabf698e745e2a1eb8"
+checksum = "5906f93257178e2f7ae069efb89fbd6ee94f0592740b5f8a1512ca498814d0fb"
 dependencies = [
- "malloc_buf",
+ "bitflags 2.6.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c1948a9be5f469deadbd6bcb86ad7ff9e47b4f632380139722f7d9840c0d42c"
+dependencies = [
+ "bitflags 2.6.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f860f8e841f6d32f754836f51e6bc7777cd7e7053cf18528233f6811d3eceb4"
+dependencies = [
+ "bitflags 2.6.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
+dependencies = [
+ "bitflags 2.6.0",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dca602628b65356b6513290a21a6405b4d4027b8b250f0b98dddbb28b7de02"
+dependencies = [
+ "bitflags 2.6.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ffa6bea72bf42c78b0b34e89c0bafac877d5f80bf91e159a5d96ea7f693ca56"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a21c6c9014b82c39515db5b396f91645182611c97d24637cf56ac01e5f8d998"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161a8b87e32610086e1a7a9e9ec39f84459db7b3a0881c1f16ca5a2605581c19"
+dependencies = [
+ "bitflags 2.6.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb3794501bb1bee12f08dcad8c61f2a5875791ad1c6f47faa71a0f033f20071"
+dependencies = [
+ "bitflags 2.6.0",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -3608,15 +3651,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "objc_id"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
-dependencies = [
- "objc",
 ]
 
 [[package]]
@@ -3677,7 +3711,7 @@ checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
- "foreign-types 0.3.2",
+ "foreign-types",
  "libc",
  "once_cell",
  "openssl-macros",
@@ -5455,7 +5489,7 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0727c46b3181e4f84e79f970e6a78d3b4054b72b6072e969ea4f07dfa4983ae2"
 dependencies = [
- "cocoa-foundation 0.1.2",
+ "cocoa-foundation",
  "core-foundation 0.9.4",
  "dyn-clonable",
  "jni",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -111,10 +111,10 @@ image = "0.25.2"
 shell-words = "1.1.0"
 
 # Used for Tray Handling
-cocoa-foundation = "0.2.0"
-cocoa = "0.26.0"
-objc-foundation = "0.1.1"
-objc = { package = "objc-rs", version = "0.2.8" }
+objc2-app-kit = "0.3.0"
+objc2-foundation = "0.3.0"
+dispatch2 = "0.2.0"
+objc2 = "0.6.0"
 
 # Used for Aggregate Device Management
 coreaudio-sys = "0.2.15"

--- a/daemon/src/platform/macos/core_audio.rs
+++ b/daemon/src/platform/macos/core_audio.rs
@@ -363,7 +363,7 @@ pub fn get_goxlr_devices() -> Result<Vec<CoreAudioDevice>> {
     let mut devices: Vec<CoreAudioDevice> = Vec::new();
 
     let mut iterator = mem::MaybeUninit::<io_iterator_t>::uninit();
-    let matcher = unsafe { IOServiceMatching(b"IOAudioEngine\0".as_ptr() as *const c_char) };
+    let matcher = unsafe { IOServiceMatching(c"IOAudioEngine".as_ptr() as *const c_char) };
     let status = unsafe {
         IOServiceGetMatchingServices(kIOMasterPortDefault, matcher, iterator.as_mut_ptr())
     };

--- a/daemon/src/tray/macos.rs
+++ b/daemon/src/tray/macos.rs
@@ -1,24 +1,27 @@
-use std::ffi::c_void;
-use std::mem;
+#![allow(deprecated)]
+
+use dispatch2::Queue;
+use enum_map::Enum;
+use log::{debug, warn};
+use objc2::rc::Retained;
+use objc2::runtime::{NSObject, NSObjectProtocol, ProtocolObject};
+use objc2::{
+    define_class, msg_send, sel, AllocAnyThread, DefinedClass, MainThreadMarker, MainThreadOnly,
+    Message,
+};
+use objc2_app_kit::{
+    NSApplication, NSApplicationActivationOptions, NSApplicationActivationPolicy,
+    NSApplicationDelegate, NSCellImagePosition, NSEvent, NSEventModifierFlags, NSEventSubtype,
+    NSEventType, NSImage, NSMenu, NSMenuItem, NSRunningApplication, NSStatusBar, NSWorkspace,
+};
+use objc2_foundation::{
+    NSAutoreleasePool, NSData, NSDistributedNotificationCenter, NSNotification, NSNotificationName,
+    NSPoint, NSSize, NSString, NSTimeInterval,
+};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::sleep;
 use std::time::Duration;
-
-use cocoa::appkit::{
-    NSApplication, NSApplicationActivateIgnoringOtherApps, NSApplicationActivationPolicyAccessory,
-    NSButton, NSEventModifierFlags, NSEventSubtype, NSEventType, NSImage, NSMenu, NSMenuItem,
-    NSRunningApplication, NSStatusBar, NSStatusItem,
-};
-use cocoa::base::nil;
-use cocoa::foundation::{NSAutoreleasePool, NSData};
-use cocoa_foundation::base::id;
-use cocoa_foundation::foundation::{NSPoint, NSSize, NSString, NSTimeInterval};
-use enum_map::Enum;
-use log::{debug, warn};
-use objc::declare::ClassDecl;
-use objc::runtime::{Class, Object, Sel, YES};
-use objc::{class, msg_send, sel, sel_impl};
 use strum::{Display, EnumIter, IntoEnumIterator};
 use tokio::select;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
@@ -96,26 +99,29 @@ async fn run_tray(mut p: RunParams) {
 
 unsafe fn stop_ns_application() {
     // First let the NSApplication know it's time to Stop..
-    let app = Class::get("NSApplication").unwrap();
-    let app: *mut Object = msg_send![app, sharedApplication];
-    app.stop_(nil);
+    let main_queue = Queue::main();
+    main_queue.exec_async(|| {
+        let mtm = MainThreadMarker::new().unwrap();
+        let app = NSApplication::sharedApplication(mtm);
+        app.stop(None);
 
-    // Next, we generate an Application Event..
-    let event: *mut Object = msg_send![class!(NSEvent),
-        otherEventWithType:NSEventType::NSApplicationDefined
-        location:NSPoint::new(0., 0.)
-        modifierFlags:NSEventModifierFlags::empty()
-        timestamp:NSTimeInterval::default()
-        windowNumber:0
-        context:nil
-        subtype:NSEventSubtype::NSWindowExposedEventType
-        data1:0
-        data2:0
-    ];
+        // Next, we generate an Application Event..
+        let event = NSEvent::otherEventWithType_location_modifierFlags_timestamp_windowNumber_context_subtype_data1_data2(
+            NSEventType::ApplicationDefined,
+            NSPoint::new(0., 0.),
+            NSEventModifierFlags::empty(),
+            NSTimeInterval::default(),
+            0,
+            None,
+            NSEventSubtype::WindowExposed.0,
+            0,
+            0,
+        ).unwrap();
 
-    // Then we send it to the NSApplication. The application RunLoop only stops after the 'next'
-    // event, so we'll force one to ensure shutdown.
-    let () = msg_send![app, postEvent:event atStart:true];
+        // Then we send it to the NSApplication. The application RunLoop only stops after the 'next'
+        // event, so we'll force one to ensure shutdown.
+        app.postEvent_atStart(&event, true)
+    });
 }
 
 #[derive(Display, Debug, Enum, EnumIter, Eq, PartialEq)]
@@ -142,48 +148,47 @@ struct AppParams {
 impl App {
     pub fn create(p: AppParams) {
         debug!("Preparing Tray..");
+        let mtm = MainThreadMarker::new().unwrap();
 
         // Step 1, create the initial release pool, and base menu..
-        unsafe { NSAutoreleasePool::new(nil) };
+        unsafe { NSAutoreleasePool::new() };
 
         // Configure the Application..
         unsafe {
-            let current = NSRunningApplication::currentApplication(nil);
-            current.activateWithOptions_(NSApplicationActivateIgnoringOtherApps);
+            let current = NSRunningApplication::currentApplication();
+            current.activateWithOptions(NSApplicationActivationOptions::ActivateIgnoringOtherApps);
         };
 
-        let app = unsafe {
-            // Create a 'Shared' application..
-            let app = Class::get("NSApplication").unwrap();
-            let app: *mut Object = msg_send![app, sharedApplication];
-            app.setActivationPolicy_(NSApplicationActivationPolicyAccessory);
-            app.activateIgnoringOtherApps_(YES);
-            app
-        };
+        let app = NSApplication::sharedApplication(mtm);
+        app.setActivationPolicy(NSApplicationActivationPolicy::Accessory);
+        app.activateIgnoringOtherApps(true);
+
+        // Setting the App Delegate..
+        let delegate = UtilityDelegate::new(
+            mtm,
+            p.sender.clone(),
+            p.global_tx.clone(),
+            p.state.shutdown_blocking.clone(),
+        );
+        let object = ProtocolObject::from_ref(&*delegate);
+        app.setDelegate(Some(object));
 
         let status = if p.show_tray.load(Ordering::Relaxed) {
             debug!("Spawning Tray..");
             unsafe {
-                let status = NSStatusBar::systemStatusBar(nil)
-                    .statusItemWithLength_(-1.)
-                    .autorelease();
+                let status = NSStatusBar::systemStatusBar().statusItemWithLength(-1.);
 
-                let button = status.button();
-                let icon = ICON;
+                let button = status.button(mtm);
+                let data = NSData::with_bytes(ICON);
+                if let Some(icon) = NSImage::initWithData(NSImage::alloc(), &data) {
+                    icon.setSize(NSSize::new(18., 18.));
+                    icon.setTemplate(false);
 
-                let nsdata = NSData::dataWithBytes_length_(
-                    nil,
-                    icon.as_ptr() as *const std::os::raw::c_void,
-                    icon.len() as u64,
-                );
-
-                let nsimage = NSImage::initWithData_(NSImage::alloc(nil), nsdata);
-                let new_size = NSSize::new(18.0, 18.0);
-
-                button.setImage_(nsimage);
-                let () = msg_send![nsimage, setSize: new_size];
-                let () = msg_send![button, setImagePosition: 2];
-                let () = msg_send![nsimage, setTemplate: false];
+                    if let Some(button) = button {
+                        button.setImage(Some(&*icon));
+                        button.setImagePosition(NSCellImagePosition::ImageLeft)
+                    }
+                }
 
                 Some(status)
             }
@@ -195,228 +200,207 @@ impl App {
         if let Some(status) = status {
             debug!("Building Menu..");
 
-            let menu = unsafe { NSMenu::new(nil).autorelease() };
-            let sub_title = unsafe { NSString::alloc(nil).init_str("Open Path") };
+            let menu = NSMenu::new(mtm);
+            let sub_title = NSString::from_str("Open Path");
 
             // Create the Main Tray Labels..
-            let configure = App::get_label("Configure GoXLR", Configure, p.sender.clone());
-            let quit = App::get_label("Quit", Quit, p.sender.clone());
+            let configure = App::get_label(mtm, "Configure GoXLR", Configure);
+            let quit = App::get_label(mtm, "Quit", Quit);
 
             // Create SubMenu Items..
-            let profiles = App::get_label("Profiles", OpenPathProfiles, p.sender.clone());
-            let mic_profiles =
-                App::get_label("Mic Profiles", OpenPathMicProfiles, p.sender.clone());
-            let presets = App::get_label("Presets", OpenPathPresets, p.sender.clone());
-            let samples = App::get_label("Samples", OpenPathSamples, p.sender.clone());
-            let icons = App::get_label("Icons", OpenPathIcons, p.sender.clone());
-            let logs = App::get_label("Logs", OpenPathLogs, p.sender.clone());
+            let profiles = App::get_label(mtm, "Profiles", OpenPathProfiles);
+            let mic_profiles = App::get_label(mtm, "Mic Profiles", OpenPathMicProfiles);
+            let presets = App::get_label(mtm, "Presets", OpenPathPresets);
+            let samples = App::get_label(mtm, "Samples", OpenPathSamples);
+            let icons = App::get_label(mtm, "Icons", OpenPathIcons);
+            let logs = App::get_label(mtm, "Logs", OpenPathLogs);
 
             debug!("Generating Sub Menu...");
             let sub_menu = unsafe {
-                let menu_item = NSMenuItem::alloc(nil);
-                let menu = NSMenu::new(nil).autorelease();
+                let menu_item = NSMenuItem::new(mtm);
+                let menu = NSMenu::new(mtm);
 
-                let () = msg_send![menu, setTitle: sub_title];
-                let () = msg_send![menu_item, setTitle: sub_title];
-                let () = msg_send![menu_item, setSubmenu: menu];
+                menu.setTitle(&sub_title);
+                menu_item.setTitle(&sub_title);
+                menu_item.setSubmenu(Some(&menu));
 
-                menu.addItem_(profiles);
-                menu.addItem_(mic_profiles);
-                menu.addItem_(App::get_separator());
-                menu.addItem_(presets);
-                menu.addItem_(samples);
-                menu.addItem_(icons);
-                menu.addItem_(App::get_separator());
-                menu.addItem_(logs);
+                menu.addItem(&profiles);
+                menu.addItem(&mic_profiles);
+                menu.addItem(&App::get_separator(mtm));
+                menu.addItem(&presets);
+                menu.addItem(&samples);
+                menu.addItem(&icons);
+                menu.addItem(&App::get_separator(mtm));
+                menu.addItem(&logs);
 
                 menu_item
             };
-            unsafe {
-                // Create the Tray Labels..
-                debug!("Generating Main Menu..");
-                menu.addItem_(configure);
-                menu.addItem_(App::get_separator());
-                menu.addItem_(sub_menu);
-                menu.addItem_(App::get_separator());
-                menu.addItem_(quit);
-            }
+
+            // Create the Tray Labels..
+            debug!("Generating Main Menu..");
+            menu.addItem(&configure);
+            menu.addItem(&App::get_separator(mtm));
+            menu.addItem(&sub_menu);
+            menu.addItem(&App::get_separator(mtm));
+            menu.addItem(&quit);
 
             unsafe {
-                status.setMenu_(menu);
+                status.setMenu(Some(&*menu));
             }
         }
 
         unsafe {
             // Before we run, register with the observer to see if shutdown is going to happen..
-            let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
-            let notification_center: id = msg_send![workspace, notificationCenter];
+            let workspace = NSWorkspace::sharedWorkspace();
+            let notification_center = workspace.notificationCenter();
 
             // Get the Distributed Notification Center (for Lock / Unlock Notifications)
-            let dnc: id = msg_send![class!(NSDistributedNotificationCenter), defaultCenter];
-
-            debug!("Creating Controller..");
-            let controller: id = msg_send![App::make_shutdown_hook_class(), alloc];
-
-            debug!("Initialising..");
-            let () = msg_send![controller, init];
-
-            debug!("Boxing Sender..");
-            let boxed = Box::new(p.global_tx.clone());
-            let ptr = Box::into_raw(boxed);
-            let ptr = ptr as *mut c_void as usize;
-            (*controller).set_ivar("EVENT_SENDER", ptr);
-
-            debug!("Boxing AtomicBool..");
-            let boxed = Box::new(p.state.shutdown_blocking.clone());
-            let ptr = Box::into_raw(boxed);
-            let ptr = ptr as *mut c_void as usize;
-            (*controller).set_ivar("STOP_BOOL", ptr);
+            let dnc = NSDistributedNotificationCenter::defaultCenter();
 
             debug!("Registering Event..");
             let event = "NSWorkspaceWillPowerOffNotification";
-            let event = NSString::alloc(nil).init_str(event).autorelease();
+            let event = NSNotificationName::from_str(event);
 
             debug!("Registering Class..");
-            let () = msg_send![notification_center, addObserver:controller selector:sel!(computerWillShutDownNotification:) name:event object: nil];
+            notification_center.addObserver_selector_name_object(
+                &delegate,
+                sel!(computerWillShutDownNotification:),
+                Some(&event),
+                None,
+            );
 
             // We probably shouldn't share pointers to the senders, but seeing as MacOS locks
             // the entire NS runtime into a single thread, we should be safe here.
             let event = "NSWorkspaceWillSleepNotification";
-            let event = NSString::alloc(nil).init_str(event).autorelease();
-            let () = msg_send![notification_center, addObserver:controller selector:sel!(computerWillSleepNotification:) name: event object: nil];
+            let event = NSNotificationName::from_str(event);
+            notification_center.addObserver_selector_name_object(
+                &delegate,
+                sel!(computerWillSleepNotification:),
+                Some(&event),
+                None,
+            );
 
             let event = "NSWorkspaceDidWakeNotification";
-            let event = NSString::alloc(nil).init_str(event).autorelease();
-            let () = msg_send![notification_center, addObserver:controller selector:sel!(computerWillWakeNotification:) name: event object: nil];
+            let event = NSNotificationName::from_str(event);
+            notification_center.addObserver_selector_name_object(
+                &delegate,
+                sel!(computerWillWakeNotification:),
+                Some(&event),
+                None,
+            );
 
             let event = "com.apple.screenIsLocked";
-            let event = NSString::alloc(nil).init_str(event).autorelease();
-            let () = msg_send![dnc, addObserver:controller selector:sel!(screenIsLocked:) name: event object: nil];
+            let event = NSNotificationName::from_str(event);
+            dnc.addObserver_selector_name_object(
+                &delegate,
+                sel!(screenIsLocked:),
+                Some(&event),
+                None,
+            );
 
             let event = "com.apple.screenIsUnlocked";
-            let event = NSString::alloc(nil).init_str(event).autorelease();
-            let () = msg_send![dnc, addObserver:controller selector:sel!(screenIsUnlocked:) name: event object: nil];
+            let event = NSNotificationName::from_str(event);
+            dnc.addObserver_selector_name_object(
+                &delegate,
+                sel!(screenIsUnlocked:),
+                Some(&event),
+                None,
+            );
 
             debug!("Running..");
             app.run();
         }
     }
 
-    fn get_label(label: &str, option: TrayOption, sender: Sender<TrayOption>) -> id {
+    fn get_label(mtm: MainThreadMarker, label: &str, option: TrayOption) -> Retained<NSMenuItem> {
         unsafe {
-            let title = NSString::alloc(nil).init_str(label).autorelease();
-            let no_key = NSString::alloc(nil).init_str("").autorelease();
-            let action = sel!(action:);
+            let title = NSString::from_str(label);
 
-            let item: *const Object = msg_send![App::make_menu_item_class(), alloc];
-            let () = msg_send![item, initWithTitle:title action:action keyEquivalent:no_key];
-            let () = msg_send![item, setTarget: item];
+            let item = NSMenuItem::new(mtm);
+            item.setAction(Some(sel!(menu_item:)));
+            item.setTitle(&title);
 
-            let item = item as id;
-            (*item).set_ivar("CALLBACK", option as usize);
+            // Two approaches for storing enum data in NSMenuItem:
+            //
+            // 1. Store enum variant index in tag (safer, simpler):
+            //    - Convert enum to its index: option as isize
+            //    - Retrieve with: TrayOption::iter().nth(item.tag() as usize).unwrap()
+            //    - Limited to simple enums without associated data
+            //
+            // 2. Store pointer to boxed data in tag (more flexible but unsafe):
+            //    let data = Box::new(option);
+            //    let ptr = Box::into_raw(data);
+            //    let tag_value = ptr as usize as isize;
+            //    item.setTag(tag_value);
+            //
+            //    // Retrieve with:
+            //    let ptr = item.tag() as usize as *mut TrayOption;
+            //    let option = &*ptr;  // Note: must not take ownership to avoid double-free
+            //
+            //    // WARNING: This causes memory leaks as boxed data is never freed
+            //    // Only use when necessary for complex data that can't be encoded as an index
 
-            // Box up and add the sender..
-            let boxed = Box::new(sender);
-            let ptr = Box::into_raw(boxed);
-            let ptr = ptr as *mut c_void as usize;
-            (*item).set_ivar("SENDER", ptr);
+            item.setTag(option as isize);
 
             item
         }
     }
 
-    fn get_separator() -> id {
-        unsafe {
-            let separator = NSMenuItem::separatorItem(nil);
-            let () = msg_send![separator, retain];
-            separator
+    fn get_separator(mtm: MainThreadMarker) -> Retained<NSMenuItem> {
+        let separator = NSMenuItem::separatorItem(mtm);
+        separator.retain();
+        separator
+    }
+}
+
+pub(crate) struct State {
+    sender: Sender<TrayOption>,
+    global_tx: Sender<EventTriggers>,
+    shutdown_signal: Arc<AtomicBool>,
+}
+
+define_class! {
+    #[unsafe(super(NSObject))]
+    #[thread_kind = MainThreadOnly]
+    #[name = "UtilityDelegate"]
+    #[ivars = State]
+    pub(crate) struct UtilityDelegate;
+
+    unsafe impl NSObjectProtocol for UtilityDelegate {}
+
+    unsafe impl NSApplicationDelegate for UtilityDelegate {
+        //Showcase function for now
+        #[unsafe(method(menu_item:))]
+        unsafe fn menu_item(&self, item: &NSMenuItem) {
+            if let Some(option) = TrayOption::iter().nth(item.tag() as usize) {
+                if self.ivars().sender.try_send(option).is_err() {
+                    warn!("Failed to send Tray Signal");
+                }
+            }
         }
     }
 
-    fn make_menu_item_class() -> &'static Class {
-        let class_name = "TrayHandler";
-        Class::get(class_name).unwrap_or_else(|| {
-            debug!("Creating MenuHandler..");
-            let superclass = class!(NSMenuItem);
-            let mut decl = ClassDecl::new(class_name, superclass).unwrap();
-
-            extern "C" fn handle(this: &Object, _: Sel, _: id) {
-                let option: usize = unsafe { *this.get_ivar("CALLBACK") };
-                let option = TrayOption::iter().nth(option).unwrap();
-
-                // The sender should be boxed..
-                let sender: Box<Sender<TrayOption>> = unsafe {
-                    let pointer_value: usize = *this.get_ivar("SENDER");
-                    let pointer = pointer_value as *mut c_void;
-                    let pointer = pointer as *mut Sender<TrayOption>;
-                    Box::from_raw(pointer)
-                };
-
-                // If this fails, we're out of luck really..
-                if sender.try_send(option).is_err() {
-                    warn!("Failed to send Tray Signal");
-                }
-                mem::forget(sender);
-            }
-
-            unsafe {
-                decl.add_method(sel!(action:), handle as extern "C" fn(&Object, _, _));
-                decl.add_ivar::<usize>("CALLBACK");
-                decl.add_ivar::<usize>("SENDER");
-            }
-
-            decl.register()
-        })
-    }
-
-    fn make_shutdown_hook_class() -> &'static Class {
-        let class_name = "PowerHandler";
-        Class::get(class_name).unwrap_or_else(|| {
-            let superclass = class!(NSObject);
-            let mut decl = ClassDecl::new(class_name, superclass).unwrap();
-
-            extern "C" fn handle_shutdown(this: &Object, _: Sel, notification: *const Object) {
-                debug!("Received Shutdown Notification! {:?}", notification);
-                let sender: Box<Sender<EventTriggers>> = unsafe {
-                    let pointer_value: usize = *this.get_ivar("EVENT_SENDER");
-                    let pointer = pointer_value as *mut c_void;
-                    let pointer = pointer as *mut Sender<EventTriggers>;
-                    Box::from_raw(pointer)
-                };
-
-                let stop: Box<Arc<AtomicBool>> = unsafe {
-                    let pointer_value: usize = *this.get_ivar("STOP_BOOL");
-                    let pointer = pointer_value as *mut c_void;
-                    let pointer = pointer as *mut Arc<AtomicBool>;
-                    Box::from_raw(pointer)
-                };
-
+    impl UtilityDelegate {
+        #[unsafe(method(computerWillShutDownNotification:))]
+        unsafe fn computer_will_shutdown(&self, notification: &NSNotification) {
+            debug!("Received Shutdown Notification! {:?}", notification);
                 // This is pretty similar to Windows, we loop until we're ready to die..
-                let _ = sender.try_send(EventTriggers::Stop(false));
+                let _ = self.ivars().global_tx.try_send(EventTriggers::Stop(false));
 
                 // Now wait for the daemon to actually stop..
                 loop {
-                    if stop.load(Ordering::Relaxed) {
+                    if self.ivars().shutdown_signal.load(Ordering::Relaxed) {
                         break;
                     } else {
                         debug!("Waiting..");
                         sleep(Duration::from_millis(100));
                     }
                 }
+        }
 
-                mem::forget(sender);
-                mem::forget(stop);
-            }
-
-            extern "C" fn handle_sleep(this: &Object, _: Sel, notification: *const Object) {
-                debug!("Received Sleep Notification! {:?}", notification);
-                let sender: Box<Sender<EventTriggers>> = unsafe {
-                    let pointer_value: usize = *this.get_ivar("EVENT_SENDER");
-                    let pointer = pointer_value as *mut c_void;
-                    let pointer = pointer as *mut Sender<EventTriggers>;
-                    Box::from_raw(pointer)
-                };
-
+        #[unsafe(method(computerWillSleepNotification:))]
+        unsafe fn computer_will_sleep(&self, notification: &NSNotification) {
+            debug!("Received Sleep Notification! {:?}", notification);
                 // Pretty much copypasta from Windows which behaves in a similar way..
                 let (tx, mut rx) = oneshot::channel();
 
@@ -425,7 +409,7 @@ impl App {
                 let max_wait = 1000 / milli_wait;
                 let mut count = 0;
 
-                if sender.try_send(EventTriggers::Sleep(tx)).is_ok() {
+                if self.ivars().global_tx.try_send(EventTriggers::Sleep(tx)).is_ok() {
                     debug!("Awaiting Sleep Response..");
                     while rx.try_recv().is_err() {
                         sleep(Duration::from_millis(milli_wait));
@@ -437,76 +421,42 @@ impl App {
                     }
                     debug!("Task Completed, allowing MacOS to Sleep");
                 }
-                mem::forget(sender);
-            }
-            extern "C" fn handle_wake(this: &Object, _: Sel, notification: *const Object) {
-                debug!("Received Wake Notification! {:?}", notification);
-                let sender: Box<Sender<EventTriggers>> = unsafe {
-                    let pointer_value: usize = *this.get_ivar("EVENT_SENDER");
-                    let pointer = pointer_value as *mut c_void;
-                    let pointer = pointer as *mut Sender<EventTriggers>;
-                    Box::from_raw(pointer)
-                };
+        }
 
-                let (tx, _rx) = oneshot::channel();
-                let _ = sender.try_send(EventTriggers::Wake(tx));
+        #[unsafe(method(computerWillWakeNotification:))]
+        unsafe fn computer_will_wake(&self, notification: &NSNotification) {
+            debug!("Received Wake Notification! {:?}", notification);
+            let (tx, _rx) = oneshot::channel();
+            let _ = self.ivars().global_tx.try_send(EventTriggers::Wake(tx));
+        }
 
-                mem::forget(sender);
-            }
+        #[unsafe(method(screenIsLocked:))]
+        unsafe fn screen_is_locked(&self, notification: &NSNotification) {
+            debug!("Received Lock Notification.. {:?}", notification);
+            let _ = self.ivars().global_tx.try_send(EventTriggers::Lock);
+        }
 
-            extern "C" fn handle_lock(this: &Object, _: Sel, notification: *const Object) {
-                debug!("Received Lock Notification.. {:?}", notification);
+        #[unsafe(method(screenIsUnlocked:))]
+        unsafe fn screen_is_unlocked(&self, notification: &NSNotification) {
+            debug!("Received Unlock Notification.. {:?}", notification);
+            let _ = self.ivars().global_tx.try_send(EventTriggers::Unlock);
+        }
+    }
+}
 
-                let sender: Box<Sender<EventTriggers>> = unsafe {
-                    let pointer_value: usize = *this.get_ivar("EVENT_SENDER");
-                    let pointer = pointer_value as *mut c_void;
-                    let pointer = pointer as *mut Sender<EventTriggers>;
-                    Box::from_raw(pointer)
-                };
+impl UtilityDelegate {
+    fn new(
+        mtm: MainThreadMarker,
+        sender: Sender<TrayOption>,
+        global_tx: Sender<EventTriggers>,
+        shutdown_signal: Arc<AtomicBool>,
+    ) -> Retained<Self> {
+        let delegate = mtm.alloc().set_ivars(State {
+            sender,
+            global_tx,
+            shutdown_signal,
+        });
 
-                let _ = sender.try_send(EventTriggers::Lock);
-                mem::forget(sender);
-            }
-
-            extern "C" fn handle_unlock(this: &Object, _: Sel, notification: *const Object) {
-                debug!("Received Unlock Notification.. {:?}", notification);
-                let sender: Box<Sender<EventTriggers>> = unsafe {
-                    let pointer_value: usize = *this.get_ivar("EVENT_SENDER");
-                    let pointer = pointer_value as *mut c_void;
-                    let pointer = pointer as *mut Sender<EventTriggers>;
-                    Box::from_raw(pointer)
-                };
-
-                let _ = sender.try_send(EventTriggers::Unlock);
-                mem::forget(sender);
-            }
-
-            unsafe {
-                decl.add_method(
-                    sel!(computerWillShutDownNotification:),
-                    handle_shutdown as extern "C" fn(&Object, Sel, *const Object),
-                );
-                decl.add_method(
-                    sel!(computerWillSleepNotification:),
-                    handle_sleep as extern "C" fn(&Object, Sel, *const Object),
-                );
-                decl.add_method(
-                    sel!(computerWillWakeNotification:),
-                    handle_wake as extern "C" fn(&Object, Sel, *const Object),
-                );
-                decl.add_method(
-                    sel!(screenIsLocked:),
-                    handle_lock as extern "C" fn(&Object, Sel, *const Object),
-                );
-                decl.add_method(
-                    sel!(screenIsUnlocked:),
-                    handle_unlock as extern "C" fn(&Object, Sel, *const Object),
-                );
-                decl.add_ivar::<usize>("EVENT_SENDER");
-                decl.add_ivar::<usize>("STOP_BOOL");
-            }
-
-            decl.register()
-        })
+        unsafe { msg_send![super(delegate), init] }
     }
 }


### PR DESCRIPTION
# Fix macOS Implementation and reinstate CI Builds

## Overview
This PR fixes the macOS implementation by migrating from `objc`/`cocoa` crates to the modern `objc2` crate. Additionally, it reinstates the macOS builds in our GitHub Actions workflows.

## Changes

### Code Changes
- Migrated from `objc` and `cocoa` crates to the modern `objc2` crate

### CI Changes
- Re-enabled macOS builds in GitHub Actions workflows