### PR TITLE
Update/Fix driver info retrival on windows.

### DIFF
--- a/daemon/src/primary_worker.rs
+++ b/daemon/src/primary_worker.rs
@@ -231,18 +231,6 @@ pub async fn spawn_usb_handler(
             }
             () = &mut detection_sleep => {
                 if let Some(device) = find_new_device(&daemon_status, &ignore_list) {
-                    if cfg!(target_os = "windows") {
-                        // Get the Driver Type and Details again as Theysecon does not show the driver
-                        // version when no device is connected..
-                        if driver_interface.version == VersionNumber::default() {
-                            let (_, version) = get_version();
-                            if version != VersionNumber::default() {
-                                debug!("Driver Version found, updating.. {}", version);
-                                driver_interface.version = version;
-                            }
-                        }
-                    }
-
                     let existing_serials: Vec<String> = get_all_serials(&devices);
                     let bus_number = device.bus_number();
                     let address = device.address();
@@ -258,6 +246,18 @@ pub async fn spawn_usb_handler(
 
                             devices.insert(serial.clone(), device);
                             change_found = true;
+
+                            if cfg!(target_os = "windows") {
+                                // Get the Driver Type and Details again as Theysecon does not show the driver
+                                // version when no device is connected..
+                                if driver_interface.version.is_none() {
+                                    let (_, version) = get_version();
+                                    if let Some(version) = version {
+                                        debug!("Driver Version found, updating.. {}", version);
+                                        driver_interface.version = Some(version);
+                                    }
+                                }
+                            }
                         }
                         Err(e) => {
                             error!(

--- a/daemon/src/primary_worker.rs
+++ b/daemon/src/primary_worker.rs
@@ -234,9 +234,9 @@ pub async fn spawn_usb_handler(
                     if cfg!(target_os = "windows") {
                         // Get the Driver Type and Details again as Theysecon does not show the driver
                         // version when no device is connected..
-                        if driver_interface.version == VersionNumber(0, 0, Some(0), None) {
+                        if driver_interface.version == VersionNumber::default() {
                             let (_, version) = get_version();
-                            if version != VersionNumber(0, 0, Some(0), None) {
+                            if version != VersionNumber::default() {
                                 debug!("Driver Version found, updating.. {}", version);
                                 driver_interface.version = version;
                             }

--- a/daemon/src/primary_worker.rs
+++ b/daemon/src/primary_worker.rs
@@ -247,15 +247,13 @@ pub async fn spawn_usb_handler(
                             devices.insert(serial.clone(), device);
                             change_found = true;
 
-                            if cfg!(target_os = "windows") {
-                                // Get the Driver Type and Details again as Theysecon does not show the driver
-                                // version when no device is connected..
-                                if driver_interface.version.is_none() {
-                                    let (_, version) = get_version();
-                                    if let Some(version) = version {
-                                        debug!("Driver Version found, updating.. {}", version);
-                                        driver_interface.version = Some(version);
-                                    }
+                            // Get the Driver Type and Details again as Theysecon does not show the driver
+                            // version when no device is connected..
+                            if driver_interface.version.is_none() {
+                                let (_, version) = get_version();
+                                if let Some(version) = version {
+                                    debug!("Driver Version found, updating.. {}", version);
+                                    driver_interface.version = Some(version);
                                 }
                             }
                         }

--- a/ipc/src/device.rs
+++ b/ipc/src/device.rs
@@ -46,7 +46,7 @@ pub struct DaemonConfig {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DriverDetails {
     pub interface: DriverInterface,
-    pub version: VersionNumber,
+    pub version: Option<VersionNumber>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/usb/src/device/libusb/device.rs
+++ b/usb/src/device/libusb/device.rs
@@ -477,15 +477,15 @@ pub fn find_devices() -> Vec<GoXLRDevice> {
     found_devices
 }
 
-pub fn get_interface_version() -> (DriverInterface, VersionNumber) {
+pub fn get_interface_version() -> (DriverInterface, Option<VersionNumber>) {
     let version = rusb::version();
     (
         DriverInterface::LIBUSB,
-        VersionNumber(
+        Some(VersionNumber(
             version.major() as u32,
             version.minor() as u32,
             Some(version.micro() as u32),
             None,
-        ),
+        )),
     )
 }

--- a/usb/src/device/mod.rs
+++ b/usb/src/device/mod.rs
@@ -13,7 +13,7 @@ cfg_if::cfg_if! {
         mod tusb;
         use crate::device::tusb::device;
 
-        pub fn get_version() -> (DriverInterface, VersionNumber) {
+        pub fn get_version() -> (DriverInterface, Option<VersionNumber>) {
             device::get_interface_version()
         }
 
@@ -34,7 +34,7 @@ cfg_if::cfg_if! {
         mod libusb;
         use crate::device::libusb::device;
 
-        pub fn get_version() -> (DriverInterface, VersionNumber) {
+        pub fn get_version() -> (DriverInterface, Option<VersionNumber>) {
             device::get_interface_version()
         }
 

--- a/usb/src/device/tusb/device.rs
+++ b/usb/src/device/tusb/device.rs
@@ -373,6 +373,6 @@ pub fn find_devices() -> Vec<GoXLRDevice> {
     get_devices()
 }
 
-pub fn get_interface_version() -> (DriverInterface, VersionNumber) {
+pub fn get_interface_version() -> (DriverInterface, Option<VersionNumber>) {
     (DriverInterface::TUSB, get_version())
 }

--- a/usb/src/device/tusb/tusbaudio.rs
+++ b/usb/src/device/tusb/tusbaudio.rs
@@ -194,6 +194,7 @@ impl TUSBAudio<'_> {
                 let result = unsafe { (get_driver_info)(driver_info_ptr) };
                 if result != 0 {
                     warn!("Unable to Get Driver Info: {}", self.get_error(result));
+                    return VersionNumber::default();
                 }
 
                 VersionNumber(
@@ -205,7 +206,7 @@ impl TUSBAudio<'_> {
             }
             Err(e) => {
                 warn!("Unable to Get Driver Info: {}", e);
-                VersionNumber(0, 0, Some(0), None)
+                VersionNumber::default()
             }
         }
     }

--- a/usb/src/device/tusb/tusbaudio.rs
+++ b/usb/src/device/tusb/tusbaudio.rs
@@ -80,9 +80,6 @@ fn locate_library() -> String {
 
 #[allow(dead_code)]
 pub struct TUSBAudio<'lib> {
-    // DriverInfo
-    driver_info: DriverInfo,
-
     // Need to enumerate..
     pnp_thread_running: Arc<Mutex<bool>>,
     discovered_devices: Arc<Mutex<Vec<String>>>,
@@ -90,9 +87,6 @@ pub struct TUSBAudio<'lib> {
     // API Related Commands
     get_api_version: Symbol<'lib, GetAPIVersion>,
     check_api_version: Symbol<'lib, CheckAPIVersion>,
-
-    // Driver Version
-    get_driver_info: Symbol<'lib, GetDriverInfo>,
 
     // Enumeration / Opening..
     enumerate_devices: Symbol<'lib, EnumerateDevices>,
@@ -122,8 +116,6 @@ impl TUSBAudio<'_> {
         let get_api_version: Symbol<_> = unsafe { LIBRARY.get(b"TUSBAUDIO_GetApiVersion")? };
         let check_api_version = unsafe { LIBRARY.get(b"TUSBAUDIO_CheckApiVersion")? };
 
-        let get_driver_info = unsafe { LIBRARY.get::<GetDriverInfo>(b"TUSBAUDIO_GetDriverInfo")? };
-
         let enumerate_devices =
             unsafe { LIBRARY.get::<EnumerateDevices>(b"TUSBAUDIO_EnumerateDevices")? };
         let open_device_by_index = unsafe { LIBRARY.get(b"TUSBAUDIO_OpenDeviceByIndex")? };
@@ -148,22 +140,12 @@ impl TUSBAudio<'_> {
         debug!("Performing initial Enumeration..");
         unsafe { (enumerate_devices)() };
 
-        debug!("Fetching Versioning Information..");
-        let mut driver_info = DriverInfo::default();
-        let driver_info_ptr: *mut DriverInfo = &mut driver_info;
-        let result = unsafe { (get_driver_info)(driver_info_ptr) };
-        if result != 0 {
-            warn!("Unable to Obtain Driver Info: {}", result);
-        }
-
         let tusb_audio = Self {
-            driver_info,
             pnp_thread_running: Arc::new(Mutex::new(false)),
             discovered_devices: Arc::new(Mutex::new(Vec::new())),
 
             get_api_version,
             check_api_version,
-            get_driver_info,
             enumerate_devices,
             open_device_by_index,
             get_device_count,
@@ -204,12 +186,28 @@ impl TUSBAudio<'_> {
     }
 
     pub fn get_driver_version(&self) -> VersionNumber {
-        VersionNumber(
-            self.driver_info.driver_major,
-            self.driver_info.driver_minor,
-            Some(self.driver_info.driver_patch),
-            None,
-        )
+        match unsafe { LIBRARY.get::<GetDriverInfo>(b"TUSBAUDIO_GetDriverInfo") } {
+            Ok(get_driver_info) => {
+                debug!("Fetching Versioning Information..");
+                let mut driver_info = DriverInfo::default();
+                let driver_info_ptr: *mut DriverInfo = &mut driver_info;
+                let result = unsafe { (get_driver_info)(driver_info_ptr) };
+                if result != 0 {
+                    warn!("Unable to Get Driver Info: {}", self.get_error(result));
+                }
+
+                VersionNumber(
+                    driver_info.driver_major,
+                    driver_info.driver_minor,
+                    Some(driver_info.driver_patch),
+                    None,
+                )
+            }
+            Err(e) => {
+                warn!("Unable to Get Driver Info: {}", e);
+                VersionNumber(0, 0, Some(0), None)
+            }
+        }
     }
 
     fn get_error(&self, error: u32) -> String {

--- a/usb/src/device/tusb/tusbaudio.rs
+++ b/usb/src/device/tusb/tusbaudio.rs
@@ -185,7 +185,7 @@ impl TUSBAudio<'_> {
         Ok(tusb_audio)
     }
 
-    pub fn get_driver_version(&self) -> VersionNumber {
+    pub fn get_driver_version(&self) -> Option<VersionNumber> {
         match unsafe { LIBRARY.get::<GetDriverInfo>(b"TUSBAUDIO_GetDriverInfo") } {
             Ok(get_driver_info) => {
                 debug!("Fetching Versioning Information..");
@@ -194,19 +194,19 @@ impl TUSBAudio<'_> {
                 let result = unsafe { (get_driver_info)(driver_info_ptr) };
                 if result != 0 {
                     warn!("Unable to Get Driver Info: {}", self.get_error(result));
-                    return VersionNumber::default();
+                    return None;
                 }
 
-                VersionNumber(
+                Some(VersionNumber(
                     driver_info.driver_major,
                     driver_info.driver_minor,
                     Some(driver_info.driver_patch),
                     None,
-                )
+                ))
             }
             Err(e) => {
                 warn!("Unable to Get Driver Info: {}", e);
-                VersionNumber::default()
+                None
             }
         }
     }
@@ -874,7 +874,7 @@ pub fn get_devices() -> Vec<GoXLRDevice> {
     list
 }
 
-pub fn get_version() -> VersionNumber {
+pub fn get_version() -> Option<VersionNumber> {
     TUSB_INTERFACE.get_driver_version()
 }
 


### PR DESCRIPTION
This PR should fix the issue of retriving the driver info/version when the Utility starts with no device connected.
Previously, when started with no device connected, connecting a device will not change the default VersionNumber (0.0.0.null) as Theysecon does not provide this without a device.

The UI part can be found here: GoXLR-on-Linux/goxlr-ui#70

Regarding the comments:
- The Windows specific flag is there, because libusb does seem to always return a Version number, i can't test for myself if its a 0.0.0.null or an actual one, but it will not error like the windows driver.
- I initially removed the fetching of the driver_info and therefore the driver version when `TUSBAudio::new()` is called as it would be always `None` when no device is connected at startup and its not used anywhere else. As a `None` value would always run the same code inside the `get_version_number(&self)` function, we can remove it being a duplicate.
- It's already a `match unsafe {...} {...}`, so no further actions needed and the unsafe block is as small as it can get