### PR TITLE
[Fix] Utility counts itself in preflight, increase to check against > 1 instead.

### DIFF
--- a/daemon/src/platform/windows.rs
+++ b/daemon/src/platform/windows.rs
@@ -36,7 +36,7 @@ pub fn perform_platform_preflight() -> Result<()> {
         bail!("The official GoXLR Application is currently running, Please close it before running the Utility");
     }
 
-    if get_utility_count() > 0 {
+    if get_utility_count() > 1 {
         error!("Daemon Process already running, Failing Preflight");
         bail!("The GoXLR Utility is already running, please stop it and try again.");
     }


### PR DESCRIPTION
As the Utility counts itself running, it counts at least 1 running goxlr-daemon.exe which leads to failure on start.
Changing `get_utility_count() > 0` to `get_utility_count() > 1`