### PR TITLE
Add tap-tempo configuration and handling for effect presets

### DIFF
--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -1191,9 +1191,12 @@ pub enum DeviceSettings {
 }
 
 fn ms_window_value(s: &str) -> Result<u16, String> {
-    let value = u16::from_str(s).map_err(|_| String::from("Value must be a number in milliseconds"))?;
+    let value =
+        u16::from_str(s).map_err(|_| String::from("Value must be a number in milliseconds"))?;
     if !(1000..=2000).contains(&value) {
-        return Err(String::from("Tap-tempo window must be between 1000 and 2000 ms"));
+        return Err(String::from(
+            "Tap-tempo window must be between 1000 and 2000 ms",
+        ));
     }
     Ok(value)
 }

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -1181,4 +1181,19 @@ pub enum DeviceSettings {
         #[arg(value_parser, action = ArgAction::Set)]
         enabled: bool,
     },
+
+    /// Configure the tap-tempo window (ms) for effect preset tapping
+    TapTempoWindow {
+        /// Window duration in milliseconds (default 1500, clamped 1000..=2000)
+        #[arg(value_parser=ms_window_value, action = ArgAction::Set)]
+        duration_ms: u16,
+    },
+}
+
+fn ms_window_value(s: &str) -> Result<u16, String> {
+    let value = u16::from_str(s).map_err(|_| String::from("Value must be a number in milliseconds"))?;
+    if !(1000..=2000).contains(&value) {
+        return Err(String::from("Tap-tempo window must be between 1000 and 2000 ms"));
+    }
+    Ok(value)
 }

--- a/client/src/runner.rs
+++ b/client/src/runner.rs
@@ -1022,6 +1022,11 @@ pub async fn run_cli() -> Result<()> {
                             .command(&serial, GoXLRCommand::SetLockFaders(*enabled))
                             .await?;
                     }
+                    DeviceSettings::TapTempoWindow { duration_ms } => {
+                        client
+                            .command(&serial, GoXLRCommand::SetTapTempoWindow(*duration_ms))
+                            .await?;
+                    }
                 },
                 SubCommands::Firmware { command } => match command {
                     FirmwareCommands::FirmwareUpdate { path } => {

--- a/daemon/src/device.rs
+++ b/daemon/src/device.rs
@@ -847,12 +847,7 @@ impl<'a> Device<'a> {
             let secs = avg.as_secs_f64();
             if secs > 0.0 {
                 let mut bpm = (60.0 / secs).round() as u16;
-                if bpm < 45 {
-                    bpm = 45;
-                }
-                if bpm > 300 {
-                    bpm = 300;
-                }
+                bpm = bpm.clamp(45, 300);
 
                 // Apply tempo to the active echo profile (current preset after load)
                 if self.profile.use_echo_tempo() {

--- a/daemon/src/device.rs
+++ b/daemon/src/device.rs
@@ -851,9 +851,8 @@ impl<'a> Device<'a> {
                     }
                     self.apply_effects(LinkedHashSet::from_iter([EffectKey::EchoTempo]))?;
 
-                    // TTS: BPM Delay for {preset} set to {bpm}
-                    let preset_name = self.profile.get_effect_name(preset);
-                    let message = format!("BPM Delay for {} set to {}", preset_name, bpm);
+                    // TTS: Tempo {tempo}
+                    let message = format!("Tempo {}", bpm);
                     let _ = self.global_events.send(TTSMessage(message)).await;
                 }
 

--- a/daemon/src/settings.rs
+++ b/daemon/src/settings.rs
@@ -527,6 +527,28 @@ impl SettingsHandle {
         100
     }
 
+    pub async fn get_tap_tempo_window(&self, device_serial: &str) -> u16 {
+        let settings = self.settings.read().await;
+        settings
+            .devices
+            .as_ref()
+            .unwrap()
+            .get(device_serial)
+            .map(|d| d.tap_tempo_window_ms.unwrap_or(1500))
+            .unwrap_or(1500)
+    }
+
+    pub async fn set_device_tap_tempo_window(&self, device_serial: &str, duration_ms: u16) {
+        let mut settings = self.settings.write().await;
+        let entry = settings
+            .devices
+            .as_mut()
+            .unwrap()
+            .entry(device_serial.to_owned())
+            .or_insert_with(DeviceSettings::default);
+        entry.tap_tempo_window_ms = Some(duration_ms);
+    }
+
     /// This exists so we don't have to repeatedly lock / unlock the struct to get individual
     /// gain values. We can simply clone off the list, and let it be handled elsewhere.
     pub async fn get_sample_gain_list(&self) -> HashMap<String, u8> {
@@ -817,6 +839,9 @@ struct DeviceSettings {
     // The time it takes for a sample to fade out
     sampler_fade_duration: Option<u32>,
 
+    // Tap-tempo window for effect preset tapping (ms)
+    tap_tempo_window_ms: Option<u16>,
+
     // VoD 'Mode'
     vod_mode: Option<VodMode>,
 
@@ -839,6 +864,7 @@ impl Default for DeviceSettings {
             enable_monitor_with_fx: Some(false),
             sampler_reset_on_clear: Some(true),
             sampler_fade_duration: Some(500),
+            tap_tempo_window_ms: Some(1500),
 
             vod_mode: Some(Routable),
 

--- a/ipc/src/device.rs
+++ b/ipc/src/device.rs
@@ -409,6 +409,7 @@ pub struct Settings {
     pub lock_faders: bool,
     pub fade_duration: u32,
     pub vod_mode: VodMode,
+    pub tap_tempo_window_ms: u16,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -308,6 +308,8 @@ pub enum GoXLRCommand {
     SetSamplerFadeDuration(u32),
     SetLockFaders(bool),
     SetVodMode(VodMode),
+    // Tap Tempo window (ms) for effect preset tap-tempo
+    SetTapTempoWindow(u16),
 
     // These control the current GoXLR 'State'..
     SetActiveEffectPreset(EffectBankPresets),


### PR DESCRIPTION
### summary
This pull request introduces tap-tempo support for effect presets, allowing users to set the tempo of echo effects by tapping preset buttons four times, and adds a configurable tap-tempo window. The implementation includes changes to the CLI, device logic, settings management, and IPC commands to support this new feature.

### **Tap-tempo feature implementation:**

* Added a new `TapTempoWindow` variant to the `DeviceSettings` CLI enum, allowing users to configure the tap-tempo window duration (1000–2000 ms) via the CLI.
* Implemented tap-tempo state tracking and logic in `daemon/src/device.rs`, including the `TapTempoState` struct, tap state management per effect preset, and logic to compute BPM from tap intervals. [[1]](diffhunk://#diff-2626e4b8e1385b6a80cda28158e8658fd115e8db2f9b92efbda54927579d2093R63-R66) [[2]](diffhunk://#diff-2626e4b8e1385b6a80cda28158e8658fd115e8db2f9b92efbda54927579d2093R81-R140) [[3]](diffhunk://#diff-2626e4b8e1385b6a80cda28158e8658fd115e8db2f9b92efbda54927579d2093R293-R297) [[4]](diffhunk://#diff-2626e4b8e1385b6a80cda28158e8658fd115e8db2f9b92efbda54927579d2093R824-R877)
* Modified effect preset button handling to support tap-tempo: consecutive taps within the window update the tempo, and effect bank loading suppresses TTS messages on subsequent taps. [[1]](diffhunk://#diff-2626e4b8e1385b6a80cda28158e8658fd115e8db2f9b92efbda54927579d2093L664-R767) [[2]](diffhunk://#diff-2626e4b8e1385b6a80cda28158e8658fd115e8db2f9b92efbda54927579d2093L1475-R1623)

#### **Settings and persistence:**

* Added tap-tempo window configuration to settings: new fields in `DeviceSettings`, default values, and getter/setter methods for device tap-tempo window. [[1]](diffhunk://#diff-ab922ea019ed277aea3988c089f2b431c1e2a925fe80805c643007b5fea95ad3R842-R844) [[2]](diffhunk://#diff-ab922ea019ed277aea3988c089f2b431c1e2a925fe80805c643007b5fea95ad3R867) [[3]](diffhunk://#diff-ab922ea019ed277aea3988c089f2b431c1e2a925fe80805c643007b5fea95ad3R530-R551)
* Updated device and IPC structures to include the tap-tempo window value, ensuring persistence and communication between daemon and client. [[1]](diffhunk://#diff-2626e4b8e1385b6a80cda28158e8658fd115e8db2f9b92efbda54927579d2093R427) [[2]](diffhunk://#diff-fe632566a0e1ef29c3a2a2d4a0526c765faf68d1de7d09a7ee4639854a5bec4cR412)

#### **IPC and command integration:**

* Added a new `SetTapTempoWindow(u16)` command to the IPC layer and integrated its handling in the device daemon, including clamping and saving the window value. [[1]](diffhunk://#diff-66290128b40986b905eff70bf067a8fc8b9f780de7bbde77989e965ad96b4584R311-R312) [[2]](diffhunk://#diff-2626e4b8e1385b6a80cda28158e8658fd115e8db2f9b92efbda54927579d2093R2937-R2945) [[3]](diffhunk://#diff-072974c208ee3614b0a5083397fd515022eb76ef41101521053668cae1835dc3R1025-R1029)

#### **UI Updates:**

* A pull request is created on the [goxlr-ui Repo](https://github.com/GoXLR-on-Linux/goxlr-ui/pull/73) to add the configurable tab tempo window to device settings.