### PR TITLE
fix: Move menu_item method out of NSApplicationDelegate impl

### DIFF
--- a/daemon/src/tray/macos.rs
+++ b/daemon/src/tray/macos.rs
@@ -372,8 +372,9 @@ define_class! {
 
     unsafe impl NSObjectProtocol for UtilityDelegate {}
 
-    unsafe impl NSApplicationDelegate for UtilityDelegate {
-        //Showcase function for now
+    unsafe impl NSApplicationDelegate for UtilityDelegate {}
+
+    impl UtilityDelegate {
         #[unsafe(method(menu_item:))]
         unsafe fn menu_item(&self, item: &NSMenuItem) {
             if let Some(option) = TrayOption::iter().nth(item.tag() as usize)
@@ -381,9 +382,7 @@ define_class! {
                     warn!("Failed to send Tray Signal");
                 }
         }
-    }
 
-    impl UtilityDelegate {
         #[unsafe(method(computerWillShutDownNotification:))]
         unsafe fn computer_will_shutdown(&self, notification: &NSNotification) {
             debug!("Received Shutdown Notification! {:?}", notification);


### PR DESCRIPTION
## Summary
- `menu_item:` is a custom target-action callback for `NSMenuItem`, not a method defined by the `NSApplicationDelegate` protocol
- `objc2 0.6.3` validates protocol methods at runtime and panics when it can't find `menu_item:` in the protocol definition
- Moves the method from `unsafe impl NSApplicationDelegate` into `impl UtilityDelegate` where the other custom methods live

Introduced in #211 during the `objc`-to-`objc2` migration.

## Environment
- **Machine:** MacBook Pro (Mac16,5) — Apple M4 Max, 64 GB RAM
- **OS:** macOS 26.2 Tahoe (25C56), Darwin 25.2.0
- **Device:** GoXLR Mini (USB ID `1220:8fe4`, Firmware `1.2.1.49`)
- **Rust toolchain:** stable

## Before fix
The daemon panics immediately on startup when initializing the macOS system tray:
```
[ERROR] thread 'main' panicked at 'failed overriding protocol method -[NSApplicationDelegate menu_item:]: method not found'
```

## After fix
The daemon starts successfully. The GoXLR Mini is detected, initialized, profile loaded, and all faders/routing/mic settings applied without issues. The system tray menu functions correctly.

## Test plan
- [x] Builds cleanly on macOS
- [x] Daemon starts without panic on macOS 26.2 Tahoe with GoXLR Mini
- [x] Device initializes and loads profile successfully
- [x] Tray menu items (Configure, Open Path submenu, Quit) respond correctly

I used Claude Opus 4.6 to find the issue and to build a fix and push a PR.